### PR TITLE
mne interface example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ notifications:
 # Install packages
 install:
   - pip install -r requirements.txt
-  - pip install -q mne
-  - pip install pactools
   - pip install pytest-cov
   - pip install codecov
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ notifications:
 # Install packages
 install:
   - pip install -r requirements.txt
+  - pip install -q mne
+  - pip install pactools
   - pip install pytest-cov
   - pip install codecov
   - pip install .

--- a/examples/plot_mne_feature_distributions.py
+++ b/examples/plot_mne_feature_distributions.py
@@ -1,0 +1,224 @@
+"""
+MNE interface cycle feature distributions
+=============================================
+This example computes the distributions of cycle features using MNE objects
+"""
+
+####################################################################################################
+
+import mne
+import numpy as np
+import matplotlib.pyplot as plt
+import scipy.signal
+
+from pactools import simulate_pac, raw_to_mask, Comodulogram
+from pactools.utils.pink_noise import pink_noise
+from pactools.utils.validation import check_random_state
+
+from bycycle.features import compute_features
+
+####################################################################################################
+# Simulate and preprocess data
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+####################################################################################################
+
+
+def simulate_spurious_pac(n_points, fs, spike_amp=1.5, spike_fwhm=0.01,
+                          spike_fq=10., spike_interval_jitter=0.2,
+                          random_state=None):
+    """Simulate some spurious phase-amplitude coupling (PAC) with spikes
+
+    References
+    ----------
+    Gerber, E. M., Sadeh, B., Ward, A., Knight, R. T., & Deouell, L. Y. (2016).
+    Non-sinusoidal activity can produce cross-frequency coupling in cortical
+    signals in the absence of functional interaction between neural sources.
+    PloS one, 11(12), e0167351
+    """
+    n_points = int(n_points)
+    fs = float(fs)
+    rng = check_random_state(random_state)
+
+    # draw the position of the spikes
+    interval_min = 1. / float(spike_fq) * (1. - spike_interval_jitter)
+    interval_max = 1. / float(spike_fq) * (1. + spike_interval_jitter)
+    n_spikes_max = np.int(n_points / fs / interval_min)
+    spike_intervals = rng.uniform(low=interval_min, high=interval_max,
+                                  size=n_spikes_max)
+    spike_positions = np.cumsum(np.int_(spike_intervals * fs))
+    spike_positions = spike_positions[spike_positions < n_points]
+
+    # build the spike time series, using a convolution
+    spikes = np.zeros(n_points)
+    spikes[spike_positions] = spike_amp
+    # full width at half maximum to standard deviation convertion
+    spike_std = spike_fwhm / (2 * np.sqrt(2 * np.log(2)))
+    spike_shape = scipy.signal.gaussian(M=np.int(spike_std * fs * 10),
+                                        std=spike_std * fs)
+    spikes = scipy.signal.fftconvolve(spikes, spike_shape, mode='same')
+
+    noise = pink_noise(n_points, slope=1., random_state=random_state)
+
+    return spikes + noise, spikes
+
+
+f_beta = (14, 28)
+trial_len = 40  # seconds
+fs = 200.  # Hz
+high_fq = 80.0  # Hz
+low_fq = 24.0  # Hz
+low_fq_width = 2.0  # Hz
+
+n_points = int(trial_len * fs)
+noise_level = 0.4
+
+# simulate beta-gamma pac
+signal_pac = simulate_pac(n_points=n_points, fs=fs,
+                          high_fq=high_fq, low_fq=low_fq,
+                          low_fq_width=low_fq_width,
+                          noise_level=noise_level, random_state=99)
+signal_spurious_pac, spikes = simulate_spurious_pac(
+    n_points=n_points, fs=fs, spike_amp=1. / noise_level, random_state=999)
+low_fq_signal = np.sin(2 * np.pi * low_fq * np.linspace(0, trial_len,
+                                                        n_points))
+signal_no_pac = low_fq_signal + pink_noise(n_points, slope=1.,
+                                           random_state=9999)
+
+info = mne.create_info(['Ch1', 'Ch2', 'Ch3'], fs, ['eeg'] * 3)
+raw = mne.io.RawArray(np.stack([signal_pac, signal_spurious_pac,
+                                signal_no_pac]) * 1e-6, info)
+
+####################################################################################################
+# Check comodulogram for PAC
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+####################################################################################################
+
+fig, axs = plt.subplots(nrows=3, figsize=(10, 12), sharex=True)
+for i, ax in enumerate(axs):
+    # check PAC within only channel
+    low_sig, high_sig, mask = raw_to_mask(raw, (i, i))
+    #
+    estimator = Comodulogram(fs=raw.info['sfreq'],
+                             low_fq_range=np.arange(1, 41), low_fq_width=2.,
+                             method='duprelatour', progress_bar=True)
+    # compute the comodulogram
+    estimator.fit(low_sig, high_sig, mask)
+    # plot the results
+    estimator.plot(axs=[ax], tight_layout=False)
+plt.show()
+
+####################################################################################################
+
+# Apply a lowpass filter at for the PAC signal
+raw = raw.filter(h_freq=30.)
+
+####################################################################################################
+#
+# Plot time series for each recording
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+####################################################################################################
+
+# plot the signal and the spikes
+n_points_plot = np.int(fs)
+time = np.arange(n_points_plot) / fs
+fig, axs = plt.subplots(nrows=4, figsize=(10, 12), sharex=True)
+axs[0].plot(time, raw[0, :n_points_plot][0][0] * 1e6, color='C0')
+axs[0].set(title='Signal with PAC', ylabel=r'$\mu V$')
+axs[1].plot(time, raw[1, :n_points_plot][0][0] * 1e6, color='C1')
+axs[1].set(title='Signal with Spurious PAC', ylabel=r'$\mu V$')
+axs[2].plot(time, spikes[:n_points_plot], color='C3')
+axs[2].set(title='Spikes', ylabel=r'$\mu V$')
+axs[3].plot(time, raw[2, :n_points_plot][0][0] * 1e6, color='C2')
+axs[3].set(xlabel='Time (sec)', title='Signal with no PAC', ylabel=r'$\mu V$')
+plt.show()
+
+####################################################################################################
+# Compute cycle-by-cycle features
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+####################################################################################################
+
+# Set parameters for defining oscillatory bursts
+osc_kwargs = {'amplitude_fraction_threshold': 0.3,
+              'amplitude_consistency_threshold': 0.4,
+              'period_consistency_threshold': 0.5,
+              'monotonicity_threshold': 0.8,
+              'n_cycles_min': 3}
+
+# Cycle-by-cycle analysis
+df_pac = compute_features(raw[0, :][0][0], fs, f_beta, center_extrema='T',
+                          burst_detection_kwargs=osc_kwargs)
+
+df_spurious = compute_features(raw[1, :][0][0], fs, f_beta, center_extrema='T',
+                               burst_detection_kwargs=osc_kwargs)
+
+df_no_pac = compute_features(raw[2, :][0][0], fs, f_beta, center_extrema='T',
+                             burst_detection_kwargs=osc_kwargs)
+
+
+####################################################################################################
+#
+# Plot feature distributions
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+####################################################################################################
+
+plt.figure(figsize=(5, 5))
+plt.hist(df_pac['volt_amp'] * 1e6, bins=np.arange(0, 8, .1),
+         color='C0', alpha=.5, label='PAC')
+plt.hist(df_spurious['volt_amp'] * 1e6, bins=np.arange(0, 8, .1),
+         color='C1', alpha=.5, label='spurious')
+plt.hist(df_no_pac['volt_amp'] * 1e6, bins=np.arange(0, 8, .1),
+         color='C2', alpha=.5, label='no PAC')
+plt.xticks(np.arange(5), size=12)
+plt.legend(fontsize=15)
+plt.yticks(size=12)
+plt.xlim((0, 4.5))
+plt.xlabel('Cycle amplitude (mV)', size=15)
+plt.ylabel('# cycles', size=15)
+plt.tight_layout()
+plt.show()
+
+plt.figure(figsize=(5, 5))
+plt.hist(df_pac['period'] / fs * 1000, bins=np.arange(0, 250, 5),
+         color='C0', alpha=.5)
+plt.hist(df_spurious['period'] / fs * 1000, bins=np.arange(0, 250, 5),
+         color='C1', alpha=.5)
+plt.hist(df_no_pac['period'] / fs * 1000, bins=np.arange(0, 250, 5),
+         color='C2', alpha=.5)
+plt.xticks(size=12)
+plt.yticks(size=12)
+plt.xlim((0, 250))
+plt.xlabel('Cycle period (ms)', size=15)
+plt.ylabel('# cycles', size=15)
+plt.tight_layout()
+plt.show()
+
+bins = np.arange(0, 1, .1)
+plt.figure(figsize=(5, 5))
+plt.hist(df_pac['time_rdsym'], bins=bins, color='C0', alpha=.5)
+plt.hist(df_spurious['time_rdsym'], bins=bins, color='C1', alpha=.5)
+plt.hist(df_no_pac['time_rdsym'], bins=bins, color='C2', alpha=.5)
+plt.xticks(size=12)
+plt.yticks(size=12)
+plt.xlim((0, 1))
+plt.xlabel('Rise-decay asymmetry\n(fraction of cycle in rise period)', size=15)
+plt.ylabel('# cycles', size=15)
+plt.tight_layout()
+plt.show()
+
+plt.figure(figsize=(5, 5))
+plt.hist(df_pac['time_ptsym'], bins=bins, color='C0', alpha=.5)
+plt.hist(df_spurious['time_ptsym'], bins=bins, color='C1', alpha=.5)
+plt.hist(df_no_pac['time_ptsym'], bins=bins, color='C2', alpha=.5)
+plt.xticks(size=12)
+plt.yticks(size=12)
+plt.xlim((0, 1))
+plt.xlabel('Peak-trough asymmetry\n(fraction of cycle in peak period)',
+           size=15)
+plt.ylabel('# cycles', size=15)
+plt.tight_layout()
+plt.show()

--- a/examples/plot_mne_feature_distributions.py
+++ b/examples/plot_mne_feature_distributions.py
@@ -39,7 +39,6 @@ def simulate_spurious_pac(n_points, fs, spike_amp=1.5, spike_fwhm=0.01,
     n_points = int(n_points)
     fs = float(fs)
     rng = check_random_state(random_state)
-
     # draw the position of the spikes
     interval_min = 1. / float(spike_fq) * (1. - spike_interval_jitter)
     interval_max = 1. / float(spike_fq) * (1. + spike_interval_jitter)
@@ -48,7 +47,6 @@ def simulate_spurious_pac(n_points, fs, spike_amp=1.5, spike_fwhm=0.01,
                                   size=n_spikes_max)
     spike_positions = np.cumsum(np.int_(spike_intervals * fs))
     spike_positions = spike_positions[spike_positions < n_points]
-
     # build the spike time series, using a convolution
     spikes = np.zeros(n_points)
     spikes[spike_positions] = spike_amp
@@ -57,9 +55,7 @@ def simulate_spurious_pac(n_points, fs, spike_amp=1.5, spike_fwhm=0.01,
     spike_shape = scipy.signal.gaussian(M=np.int(spike_std * fs * 10),
                                         std=spike_std * fs)
     spikes = scipy.signal.fftconvolve(spikes, spike_shape, mode='same')
-
     noise = pink_noise(n_points, slope=1., random_state=random_state)
-
     return spikes + noise, spikes
 
 
@@ -108,11 +104,6 @@ for i, ax in enumerate(axs):
     # plot the results
     estimator.plot(axs=[ax], tight_layout=False)
 plt.show()
-
-####################################################################################################
-
-# Apply a lowpass filter at for the PAC signal
-raw = raw.filter(h_freq=30.)
 
 ####################################################################################################
 #

--- a/examples/plot_mne_feature_distributions.py
+++ b/examples/plot_mne_feature_distributions.py
@@ -1,163 +1,87 @@
 """
 MNE interface cycle feature distributions
 =============================================
-This example computes the distributions of cycle features using MNE objects
+This example computes the distributions of bycycle features using MNE objects
 """
 
-"""
-First let's import the packages we need. This example depends on mne as well as
-the pactools simulator to make pac and a spurious pac function from the
-pactools spurious pac example.
-"""
+####################################################################################################
+# Import Packages and Load Data
+# -----------------------------
+#
+# First let's import the packages we need. This example depends on mne as well
+# as the pactools simulator to make pac and a spurious pac function from the
+# pactools spurious pac example.
 ####################################################################################################
 
 import mne
+from mne.datasets import sample
 import numpy as np
 import matplotlib.pyplot as plt
-import scipy.signal
-
-from pactools import simulate_pac, raw_to_mask, Comodulogram
-from pactools.utils.pink_noise import pink_noise
-from pactools.utils.validation import check_random_state
 
 from bycycle.features import compute_features
 
+###################################################################################################
 
-def simulate_spurious_pac(n_points, fs, spike_amp=1.5, spike_fwhm=0.01,
-                          spike_fq=10., spike_interval_jitter=0.2,
-                          random_state=None):
-    """Simulate some spurious phase-amplitude coupling (PAC) with spikes
+# frequencies of interest: the alpha band
+f_alpha = (8, 15)
 
-    References
-    ----------
-    Gerber, E. M., Sadeh, B., Ward, A., Knight, R. T., & Deouell, L. Y. (2016).
-    Non-sinusoidal activity can produce cross-frequency coupling in cortical
-    signals in the absence of functional interaction between neural sources.
-    PloS one, 11(12), e0167351
-    """
-    n_points = int(n_points)
-    fs = float(fs)
-    rng = check_random_state(random_state)
-    # draw the position of the spikes
-    interval_min = 1. / float(spike_fq) * (1. - spike_interval_jitter)
-    interval_max = 1. / float(spike_fq) * (1. + spike_interval_jitter)
-    n_spikes_max = np.int(n_points / fs / interval_min)
-    spike_intervals = rng.uniform(low=interval_min, high=interval_max,
-                                  size=n_spikes_max)
-    spike_positions = np.cumsum(np.int_(spike_intervals * fs))
-    spike_positions = spike_positions[spike_positions < n_points]
-    # build the spike time series, using a convolution
-    spikes = np.zeros(n_points)
-    spikes[spike_positions] = spike_amp
-    # full width at half maximum to standard deviation convertion
-    spike_std = spike_fwhm / (2 * np.sqrt(2 * np.log(2)))
-    spike_shape = scipy.signal.gaussian(M=np.int(spike_std * fs * 10),
-                                        std=spike_std * fs)
-    spikes = scipy.signal.fftconvolve(spikes, spike_shape, mode='same')
-    noise = pink_noise(n_points, slope=1., random_state=random_state)
-    return spikes + noise, spikes
+# Get the data path for the MNE example data
+raw_fname = sample.data_path() + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
-####################################################################################################
-# Simulate and preprocess data
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Load the file of example MNE data
+raw = mne.io.read_raw_fif(raw_fname, preload=True, verbose=False)
 
-"""
-Now we will use the imported functions to make an mne raw object with the data.
-Ch1 will be the pac data, Ch2 will be the spurious pac data and Ch3 will be a
-sine wave with pink noise.
-"""
-####################################################################################################
+###################################################################################################
 
+# Select EEG channels from the dataset
+raw = raw.pick_types(meg=False, eeg=True, eog=False, exclude='bads')
 
+# Grab the sampling rate from the data
+fs = raw.info['sfreq']
 
-f_beta = (14, 28)
-trial_len = 40  # seconds
-fs = 200.  # Hz
-high_fq = 80.0  # Hz; carrier frequency
-low_fq = 24.0  # Hz; driver frequency
-low_fq_width = 2.0  # Hz
+# filter to alpha
+raw = raw.filter(l_freq=None, h_freq=20.)
 
-n_points = int(trial_len * fs)
-noise_level = 0.25
+###################################################################################################
 
-# simulate beta-gamma pac
-signal_pac = simulate_pac(n_points=n_points, fs=fs,
-                          high_fq=high_fq, low_fq=low_fq,
-                          low_fq_width=low_fq_width,
-                          noise_level=noise_level, random_state=99)
-# simulate 10 Hz spiking which couples to about 60 Hz
-signal_spurious_pac, spikes = simulate_spurious_pac(
-    n_points=n_points, fs=fs, spike_amp=1. / noise_level, random_state=999)
-# make a sine wave that is the driver frequency
-low_fq_signal = np.sin(2 * np.pi * low_fq * np.linspace(0, trial_len,
-                                                        n_points))
-# add the sine wave to pink noise to make a control, no pac signal
-signal_no_pac = low_fq_signal + pink_noise(n_points, slope=1.,
-                                           random_state=9999)
+# Settings for exploring example channels of data (with colors to plot)
+chs = {'EEG 042': 'C0', 'EEG 043': 'C1', 'EEG 044': 'C2'}
+t_start = 20000
+t_stop = int(t_start + (10 * fs))
 
-info = mne.create_info(['Ch1', 'Ch2', 'Ch3'], fs, ['eeg'] * 3)
-# combine into raw object, scale from volts to microvolts
-raw = mne.io.RawArray(np.stack([signal_pac, signal_spurious_pac,
-                                signal_no_pac]) * 1e-6, info)
+###################################################################################################
 
-####################################################################################################
-# Check comodulogram for PAC
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~
-"""
-Now, we will use the tools from pactools to compute the comodulogram which
-is a visualization of phase amplitude coupling. The stronger the driver
-phase couples with a particular frequency, the brighter the color value.
-The pac signal has 24 - 80 Hz pac as designed, the spurious pac has 10 - 60 Hz
-spurious pac and the final signal has no pac, just background noise.
-"""
-####################################################################################################
-
-fig, axs = plt.subplots(nrows=3, figsize=(10, 12), sharex=True)
-for i, ax in enumerate(axs):
-    # check PAC within only channel; high and low sig are the same-- channel i
-    low_sig, high_sig, mask = raw_to_mask(raw, (i, i))  # mask is all points
-    # use the duprelatour driven autoregressive model to fit the data
-    estimator = Comodulogram(fs=raw.info['sfreq'],
-                             low_fq_range=np.arange(1, 41), low_fq_width=2.,
-                             method='duprelatour', progress_bar=True)
-    # compute the comodulogram
-    estimator.fit(low_sig, high_sig, mask)
-    # plot the results
-    estimator.plot(axs=[ax], tight_layout=False)
-plt.show()
+# Extract an example channels to explore
+sig, times = raw.get_data(mne.pick_channels(raw.ch_names, list(chs.keys())),
+                          start=t_start, stop=t_stop, return_times=True)
 
 ####################################################################################################
 #
 # Plot time series for each recording
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-"""
-Now let's see how each signal looks in time. The third plot of spikes is added
-to pink noise to make the second plot which is the spurious pac. This is so
-that where the spikes occur can be noted in the spurious pac plot.
-"""
+#
+# Now let's see how each signal looks in time. This looks like standard EEG
+# data.
+#
+
 ####################################################################################################
 
-# plot the signal and the spikes
-n_points_plot = np.int(fs)
-time = np.arange(n_points_plot) / fs
-fig, axs = plt.subplots(nrows=4, figsize=(10, 12), sharex=True)
-axs[0].plot(time, raw[0, :n_points_plot][0][0] * 1e6, color='C0')
-axs[0].set(title='Signal with PAC', ylabel=r'$\mu V$')
-axs[1].plot(time, raw[1, :n_points_plot][0][0] * 1e6, color='C1')
-axs[1].set(title='Signal with Spurious PAC', ylabel=r'$\mu V$')
-axs[2].plot(time, spikes[:n_points_plot], color='C3')
-axs[2].set(title='Spikes', ylabel=r'$\mu V$')
-axs[3].plot(time, raw[2, :n_points_plot][0][0] * 1e6, color='C2')
-axs[3].set(xlabel='Time (sec)', title='Signal with no PAC', ylabel=r'$\mu V$')
+# plot the signal
+fig, ax = plt.subplots(figsize=(10, 4))
+for ch, sig0 in zip(chs, sig):
+    ax.plot(times, sig0 * 1e6, color=chs[ch], label=ch)
+ax.set(title='EEG Signal', xlabel='Time (sec)', ylabel=r'$\mu V$')
+ax.legend()
 plt.show()
 
 ####################################################################################################
 # Compute cycle-by-cycle features
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-"""
-Here we use the bycycle compute_features function to compute the cycle-by-
-cycle features of the three signals.
-"""
+#
+# Here we use the bycycle compute_features function to compute the cycle-by-
+# cycle features of the three signals.
+#
+
 ####################################################################################################
 
 # Set parameters for defining oscillatory bursts
@@ -167,50 +91,43 @@ osc_kwargs = {'amplitude_fraction_threshold': 0.3,
               'monotonicity_threshold': 0.8,
               'n_cycles_min': 3}
 
-# Cycle-by-cycle analysis
-df_pac = compute_features(raw[0, :][0][0], fs, f_beta, center_extrema='T',
-                          burst_detection_kwargs=osc_kwargs)
-
-df_spurious = compute_features(raw[1, :][0][0], fs, f_beta, center_extrema='T',
+dfs = dict()
+for ch, sig0 in zip(chs, sig):
+    # Cycle-by-cycle analysis
+    dfs[ch] = compute_features(sig0, fs, f_alpha, center_extrema='T',
                                burst_detection_kwargs=osc_kwargs)
-
-df_no_pac = compute_features(raw[2, :][0][0], fs, f_beta, center_extrema='T',
-                             burst_detection_kwargs=osc_kwargs)
 
 
 ####################################################################################################
 #
 # Plot feature distributions
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
-"""
-As shown in the feature distributions, the pac signal displays some peak-
-tough asymmetry as does the spurious pac signal.
-"""
+#
+# As it turns out, none of the channels in the mne example audio and visual
+# task has waveform asymmetry. These data were collected from a healthy
+# person while they listened to beeps or saw gratings on a screen
+# so this is not unexpected.
+#
+
 ####################################################################################################
 
 plt.figure(figsize=(5, 5))
-plt.hist(df_pac['volt_amp'] * 1e6, bins=np.arange(0, 8, .1),
-         color='C0', alpha=.5, label='PAC')
-plt.hist(df_spurious['volt_amp'] * 1e6, bins=np.arange(0, 8, .1),
-         color='C1', alpha=.5, label='spurious')
-plt.hist(df_no_pac['volt_amp'] * 1e6, bins=np.arange(0, 8, .1),
-         color='C2', alpha=.5, label='no PAC')
-plt.xticks(np.arange(5), size=12)
+for ch, df in dfs.items():
+    plt.hist(df['volt_amp'] * 1e6, bins=np.arange(0, 40, 4),
+             color=chs[ch], alpha=.5, label=ch)
+plt.xticks(np.arange(0, 40, 4), size=12)
 plt.legend(fontsize=15)
 plt.yticks(size=12)
-plt.xlim((0, 4.5))
+plt.xlim((0, 40.5))
 plt.xlabel('Cycle amplitude (mV)', size=15)
 plt.ylabel('# cycles', size=15)
 plt.tight_layout()
 plt.show()
 
 plt.figure(figsize=(5, 5))
-plt.hist(df_pac['period'] / fs * 1000, bins=np.arange(0, 250, 5),
-         color='C0', alpha=.5)
-plt.hist(df_spurious['period'] / fs * 1000, bins=np.arange(0, 250, 5),
-         color='C1', alpha=.5)
-plt.hist(df_no_pac['period'] / fs * 1000, bins=np.arange(0, 250, 5),
-         color='C2', alpha=.5)
+for ch, df in dfs.items():
+    plt.hist(df['period'] / fs * 1000, bins=np.arange(0, 250, 25),
+             color=chs[ch], alpha=.5)
 plt.xticks(size=12)
 plt.yticks(size=12)
 plt.xlim((0, 250))
@@ -221,9 +138,8 @@ plt.show()
 
 bins = np.arange(0, 1, .1)
 plt.figure(figsize=(5, 5))
-plt.hist(df_pac['time_rdsym'], bins=bins, color='C0', alpha=.5)
-plt.hist(df_spurious['time_rdsym'], bins=bins, color='C1', alpha=.5)
-plt.hist(df_no_pac['time_rdsym'], bins=bins, color='C2', alpha=.5)
+for ch, df in dfs.items():
+    plt.hist(df['time_rdsym'], bins=bins, color=chs[ch], alpha=.5)
 plt.xticks(size=12)
 plt.yticks(size=12)
 plt.xlim((0, 1))
@@ -233,9 +149,8 @@ plt.tight_layout()
 plt.show()
 
 plt.figure(figsize=(5, 5))
-plt.hist(df_pac['time_ptsym'], bins=bins, color='C0', alpha=.5)
-plt.hist(df_spurious['time_ptsym'], bins=bins, color='C1', alpha=.5)
-plt.hist(df_no_pac['time_ptsym'], bins=bins, color='C2', alpha=.5)
+for ch, df in dfs.items():
+    plt.hist(df['time_ptsym'], bins=bins, color=chs[ch], alpha=.5)
 plt.xticks(size=12)
 plt.yticks(size=12)
 plt.xlim((0, 1))

--- a/examples/plot_mne_feature_distributions.py
+++ b/examples/plot_mne_feature_distributions.py
@@ -1,6 +1,6 @@
 """
-MNE interface cycle feature distributions
-=============================================
+MNE Interface Cycle Feature Distributions
+=========================================
 This example computes the distributions of bycycle features using MNE objects
 """
 
@@ -8,30 +8,30 @@ This example computes the distributions of bycycle features using MNE objects
 # Import Packages and Load Data
 # -----------------------------
 #
-# First let's import the packages we need. This example depends on mne as well
-# as the pactools simulator to make pac and a spurious pac function from the
-# pactools spurious pac example.
+# First let's import the packages we need. This example depends on mne.
 ####################################################################################################
 
-import mne
-from mne.datasets import sample
 import numpy as np
 import matplotlib.pyplot as plt
 
+from mne.io import read_raw_fif
+from mne.datasets import sample
+from mne import pick_channels
+
+from neurodsp.plts import plot_time_series
 from bycycle.features import compute_features
+from bycycle.plts import plot_feature_hist
 
 ###################################################################################################
 
-# frequencies of interest: the alpha band
+# Frequencies of interest: the alpha band
 f_alpha = (8, 15)
 
 # Get the data path for the MNE example data
 raw_fname = sample.data_path() + '/MEG/sample/sample_audvis_filt-0-40_raw.fif'
 
 # Load the file of example MNE data
-raw = mne.io.read_raw_fif(raw_fname, preload=True, verbose=False)
-
-###################################################################################################
+raw = read_raw_fif(raw_fname, preload=True, verbose=False)
 
 # Select EEG channels from the dataset
 raw = raw.pick_types(meg=False, eeg=True, eog=False, exclude='bads')
@@ -42,18 +42,14 @@ fs = raw.info['sfreq']
 # filter to alpha
 raw = raw.filter(l_freq=None, h_freq=20.)
 
-###################################################################################################
-
-# Settings for exploring example channels of data (with colors to plot)
-chs = {'EEG 042': 'C0', 'EEG 043': 'C1', 'EEG 044': 'C2'}
+# Settings for exploring example channels of data
+chs = ['EEG 042', 'EEG 043', 'EEG 044']
 t_start = 20000
 t_stop = int(t_start + (10 * fs))
 
-###################################################################################################
-
 # Extract an example channels to explore
-sig, times = raw.get_data(mne.pick_channels(raw.ch_names, list(chs.keys())),
-                          start=t_start, stop=t_stop, return_times=True)
+sigs, times = raw.get_data(pick_channels(raw.ch_names, chs),
+                           start=t_start, stop=t_stop, return_times=True)
 
 ####################################################################################################
 #
@@ -66,13 +62,8 @@ sig, times = raw.get_data(mne.pick_channels(raw.ch_names, list(chs.keys())),
 
 ####################################################################################################
 
-# plot the signal
-fig, ax = plt.subplots(figsize=(10, 4))
-for ch, sig0 in zip(chs, sig):
-    ax.plot(times, sig0 * 1e6, color=chs[ch], label=ch)
-ax.set(title='EEG Signal', xlabel='Time (sec)', ylabel=r'$\mu V$')
-ax.legend()
-plt.show()
+# Plot the signal
+plot_time_series(times, [sig * 1e6 for sig in sigs], labels=chs, title='EEG Signal')
 
 ####################################################################################################
 # Compute cycle-by-cycle features
@@ -91,12 +82,13 @@ osc_kwargs = {'amplitude_fraction_threshold': 0.3,
               'monotonicity_threshold': 0.8,
               'n_cycles_min': 3}
 
+# Create a dictionary of cycle feature dataframes, corresponding to each channel
 dfs = dict()
-for ch, sig0 in zip(chs, sig):
-    # Cycle-by-cycle analysis
-    dfs[ch] = compute_features(sig0, fs, f_alpha, center_extrema='T',
-                               burst_detection_kwargs=osc_kwargs)
 
+for sig, ch in zip(sigs, chs):
+    # Cycle-by-cycle analysis
+    dfs[ch] = compute_features(sig, fs, f_alpha, center_extrema='trough',
+                                burst_detection_kwargs=osc_kwargs, return_samples=False)
 
 ####################################################################################################
 #
@@ -111,51 +103,23 @@ for ch, sig0 in zip(chs, sig):
 
 ####################################################################################################
 
-plt.figure(figsize=(5, 5))
-for ch, df in dfs.items():
-    plt.hist(df['volt_amp'] * 1e6, bins=np.arange(0, 40, 4),
-             color=chs[ch], alpha=.5, label=ch)
-plt.xticks(np.arange(0, 40, 4), size=12)
-plt.legend(fontsize=15)
-plt.yticks(size=12)
-plt.xlim((0, 40.5))
-plt.xlabel('Cycle amplitude (mV)', size=15)
-plt.ylabel('# cycles', size=15)
-plt.tight_layout()
-plt.show()
+fig, axes = plt.subplots(figsize=(15, 15), nrows=2, ncols=2)
 
-plt.figure(figsize=(5, 5))
 for ch, df in dfs.items():
-    plt.hist(df['period'] / fs * 1000, bins=np.arange(0, 250, 25),
-             color=chs[ch], alpha=.5)
-plt.xticks(size=12)
-plt.yticks(size=12)
-plt.xlim((0, 250))
-plt.xlabel('Cycle period (ms)', size=15)
-plt.ylabel('# cycles', size=15)
-plt.tight_layout()
-plt.show()
 
-bins = np.arange(0, 1, .1)
-plt.figure(figsize=(5, 5))
-for ch, df in dfs.items():
-    plt.hist(df['time_rdsym'], bins=bins, color=chs[ch], alpha=.5)
-plt.xticks(size=12)
-plt.yticks(size=12)
-plt.xlim((0, 1))
-plt.xlabel('Rise-decay asymmetry\n(fraction of cycle in rise period)', size=15)
-plt.ylabel('# cycles', size=15)
-plt.tight_layout()
-plt.show()
+    # Rescale amplitude and period features
+    df['volt_amp'] = df['volt_amp'] * 1e6
+    df['period'] = df['period'] / fs * 1000
 
-plt.figure(figsize=(5, 5))
-for ch, df in dfs.items():
-    plt.hist(df['time_ptsym'], bins=bins, color=chs[ch], alpha=.5)
-plt.xticks(size=12)
-plt.yticks(size=12)
-plt.xlim((0, 1))
-plt.xlabel('Peak-trough asymmetry\n(fraction of cycle in peak period)',
-           size=15)
-plt.ylabel('# cycles', size=15)
-plt.tight_layout()
-plt.show()
+    # Plot feature histograms
+    plot_feature_hist(df, 'volt_amp', only_bursts=False, ax=axes[0][0], label=ch,
+                      xlabel='Cycle amplitude (mV)', bins=np.arange(0, 40, 4))
+
+    plot_feature_hist(df, 'period', only_bursts=False, ax=axes[0][1], label=ch,
+                      xlabel='Cycle period (ms)', bins=np.arange(0, 250, 25))
+
+    plot_feature_hist(df, 'time_rdsym', only_bursts=False, ax=axes[1][0], label=ch,
+                      xlabel='Rise-decay asymmetry', bins=np.arange(0, 1, .1))
+
+    plot_feature_hist(df, 'time_ptsym', only_bursts=False, ax=axes[1][1], label=ch,
+                      xlabel='Peak-trough asymmetry', bins=np.arange(0, 1, .1))

--- a/examples/plot_pac_feature_distributions.py
+++ b/examples/plot_pac_feature_distributions.py
@@ -1,5 +1,5 @@
 """
-PAC cycle feature distributions
+PAC Cycle Feature Distributions
 ===============================
 This example computes the distributions of bycycle for simulated
 phase-amplitude coupling (PAC)
@@ -16,51 +16,20 @@ phase-amplitude coupling (PAC)
 
 import numpy as np
 import matplotlib.pyplot as plt
-import scipy.signal
 
 from pactools import simulate_pac, Comodulogram
 from pactools.utils.pink_noise import pink_noise
-from pactools.utils.validation import check_random_state
+
+from neurodsp.plts import plot_time_series
+from neurodsp.sim import sim_oscillation
+from neurodsp.utils.norm import normalize_variance
 
 from bycycle.features import compute_features
+from bycycle.plts import plot_feature_hist
 
-
-def simulate_spurious_pac(n_points, fs, spike_amp=1.5, spike_fwhm=0.01,
-                          spike_fq=10., spike_interval_jitter=0.2,
-                          random_state=None):
-    """Simulate some spurious phase-amplitude coupling (PAC) with spikes
-
-    References
-    ----------
-    Gerber, E. M., Sadeh, B., Ward, A., Knight, R. T., & Deouell, L. Y. (2016).
-    Non-sinusoidal activity can produce cross-frequency coupling in cortical
-    signals in the absence of functional interaction between neural sources.
-    PloS one, 11(12), e0167351
-    """
-    n_points = int(n_points)
-    fs = float(fs)
-    rng = check_random_state(random_state)
-    # draw the position of the spikes
-    interval_min = 1. / float(spike_fq) * (1. - spike_interval_jitter)
-    interval_max = 1. / float(spike_fq) * (1. + spike_interval_jitter)
-    n_spikes_max = np.int(n_points / fs / interval_min)
-    spike_intervals = rng.uniform(low=interval_min, high=interval_max,
-                                  size=n_spikes_max)
-    spike_positions = np.cumsum(np.int_(spike_intervals * fs))
-    spike_positions = spike_positions[spike_positions < n_points]
-    # build the spike time series, using a convolution
-    spikes = np.zeros(n_points)
-    spikes[spike_positions] = spike_amp
-    # full width at half maximum to standard deviation convertion
-    spike_std = spike_fwhm / (2 * np.sqrt(2 * np.log(2)))
-    spike_shape = scipy.signal.gaussian(M=np.int(spike_std * fs * 10),
-                                        std=spike_std * fs)
-    spikes = scipy.signal.fftconvolve(spikes, spike_shape, mode='same')
-    noise = pink_noise(n_points, slope=1., random_state=random_state)
-    return spikes + noise, spikes
 
 ####################################################################################################
-# Simulate pac data
+# Simulate PAC data
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Now we will use the imported functions to make pac data, spurious pac data
@@ -69,56 +38,58 @@ def simulate_spurious_pac(n_points, fs, spike_amp=1.5, spike_fwhm=0.01,
 
 ####################################################################################################
 
+n_seconds = 20
+fs = 200.  # Hz
+n_points = int(n_seconds * fs)
 
 f_beta = (14, 28)
-trial_len = 40  # seconds
-fs = 200.  # Hz
 high_fq = 80.0  # Hz; carrier frequency
 low_fq = 24.0  # Hz; driver frequency
 low_fq_width = 2.0  # Hz
 
-n_points = int(trial_len * fs)
 noise_level = 0.25
 
-# simulate beta-gamma pac
-signal_pac = simulate_pac(n_points=n_points, fs=fs,
-                          high_fq=high_fq, low_fq=low_fq,
-                          low_fq_width=low_fq_width,
-                          noise_level=noise_level, random_state=99)
-# simulate 10 Hz spiking which couples to about 60 Hz
-signal_spurious_pac, spikes = simulate_spurious_pac(
-    n_points=n_points, fs=fs, spike_amp=1. / noise_level, random_state=999)
-# make a sine wave that is the driver frequency
-low_fq_signal = np.sin(2 * np.pi * low_fq * np.linspace(0, trial_len,
-                                                        n_points))
-# add the sine wave to pink noise to make a control, no pac signal
-signal_no_pac = low_fq_signal + pink_noise(n_points, slope=1.,
-                                           random_state=9999)
+# Simulate beta-gamma pac
+sig_pac = simulate_pac(n_points=n_points, fs=fs, high_fq=high_fq, low_fq=low_fq,
+                       low_fq_width=low_fq_width, noise_level=noise_level)
+
+# Simulate 10 Hz spiking which couples to about 60 Hz
+spikes = sim_oscillation(n_seconds, fs, 10, cycle='gaussian', std=0.005)
+noise = normalize_variance(pink_noise(n_points, slope=1.), variance=.5, select_nonzero=False)
+sig_spurious_pac = spikes + noise
+
+# Simulate a sine wave that is the driver frequency
+sig_low_fq = sim_oscillation(n_seconds, fs, low_fq)
+
+# Add the sine wave to pink noise to make a control, no pac signal
+sig_no_pac = sig_low_fq + noise
 
 ####################################################################################################
 # Check comodulogram for PAC
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
-"""
-Now, we will use the tools from pactools to compute the comodulogram which
-is a visualization of phase amplitude coupling. The stronger the driver
-phase couples with a particular frequency, the brighter the color value.
-The pac signal has 24 - 80 Hz pac as designed, the spurious pac has 10 - 60 Hz
-spurious pac and the final signal has no pac, just background noise.
-"""
+#
+# Now, we will use the tools from pactools to compute the comodulogram which
+# is a visualization of phase amplitude coupling. The stronger the driver
+# phase couples with a particular frequency, the brighter the color value.
+# The pac signal has 24 - 80 Hz pac as designed, the spurious pac has 10 - 60 Hz
+# spurious pac and the final signal has no pac, just background noise.
+
 ####################################################################################################
 
 fig, axs = plt.subplots(nrows=3, figsize=(10, 12), sharex=True)
-for signal, ax in zip((signal_pac, signal_spurious_pac, signal_no_pac), axs):
-    # check PAC within only channel; high and low sig are the same-- channel i
-    # use the duprelatour driven autoregressive model to fit the data
-    estimator = Comodulogram(fs=fs, low_fq_range=np.arange(1, 41),
-                             low_fq_width=2., method='duprelatour',
-                             progress_bar=True)
-    # compute the comodulogram
-    estimator.fit(signal)
-    # plot the results
-    estimator.plot(axs=[ax], tight_layout=False)
-plt.show()
+titles = ['Signal with PAC', 'Signal with Spurious PAC', 'Signal with no  PAC']
+for sig, ax, title in zip((sig_pac, sig_spurious_pac, sig_no_pac), axs, titles):
+
+    # Check PAC within only channel; high and low sig are the same
+    #   Use the duprelatour driven autoregressive model to fit the data
+    estimator = Comodulogram(fs=fs, low_fq_range=np.arange(1, 41), low_fq_width=2.,
+                             method='duprelatour', progress_bar=False)
+
+    # Compute the comodulogram
+    estimator.fit(sig)
+
+    # Plot the results
+    estimator.plot(axs=[ax], tight_layout=False, titles=[title])
 
 ####################################################################################################
 #
@@ -132,19 +103,22 @@ plt.show()
 
 ####################################################################################################
 
-# plot the signal and the spikes
-n_points_plot = np.int(fs)
-time = np.arange(n_points_plot) / fs
-fig, axs = plt.subplots(nrows=4, figsize=(10, 12), sharex=True)
-axs[0].plot(time, signal_pac[:n_points_plot], color='C0')
-axs[0].set(title='Signal with PAC', ylabel=r'$\mu V$')
-axs[1].plot(time, signal_spurious_pac[:n_points_plot], color='C1')
-axs[1].set(title='Signal with Spurious PAC', ylabel=r'$\mu V$')
-axs[2].plot(time, spikes[:n_points_plot], color='C3')
-axs[2].set(title='Spikes', ylabel=r'$\mu V$')
-axs[3].plot(time, signal_no_pac[:n_points_plot], color='C2')
-axs[3].set(xlabel='Time (sec)', title='Signal with no PAC', ylabel=r'$\mu V$')
-plt.show()
+time = np.arange(0, n_seconds, 1/fs)
+
+fig, axes = plt.subplots(nrows=4, figsize=(16, 12), sharex=True)
+xlim = (0, 1)
+
+# Plot PAC
+plot_time_series(time, sig_pac, title=titles[0], xlabel='', colors='C0', ax=axes[0], xlim=xlim)
+
+# Plot spurious PAC
+plot_time_series(time, sig_spurious_pac, title=titles[1], xlabel='', colors='C1', ax=axes[1], xlim=xlim)
+
+# Plot spikes
+plot_time_series(time, spikes, title='Spikes', xlabel='', colors='C2', ax=axes[2], xlim=xlim)
+
+# Plot signal with no PAC
+plot_time_series(time, sig_no_pac, title=titles[2], colors='C3', ax=axes[3], xlim=xlim)
 
 ####################################################################################################
 # Compute cycle-by-cycle features
@@ -164,15 +138,15 @@ osc_kwargs = {'amplitude_fraction_threshold': 0.3,
               'n_cycles_min': 3}
 
 # Cycle-by-cycle analysis
-df_pac = compute_features(signal_pac, fs, f_beta, center_extrema='T',
-                          burst_detection_kwargs=osc_kwargs)
+dfs = dict()
+dfs['pac'] = compute_features(sig_pac, fs, f_beta, center_extrema='trough',
+                              burst_detection_kwargs=osc_kwargs, return_samples=False)
 
-df_spurious = compute_features(signal_spurious_pac, fs, f_beta,
-                               center_extrema='T',
-                               burst_detection_kwargs=osc_kwargs)
+dfs['spurious'] = compute_features(sig_spurious_pac, fs, f_beta, center_extrema='trough',
+                                   burst_detection_kwargs=osc_kwargs, return_samples=False)
 
-df_no_pac = compute_features(signal_no_pac, fs, f_beta, center_extrema='T',
-                             burst_detection_kwargs=osc_kwargs)
+dfs['no_pac'] = compute_features(sig_no_pac, fs, f_beta, center_extrema='trough',
+                                 burst_detection_kwargs=osc_kwargs, return_samples=False)
 
 
 ####################################################################################################
@@ -186,63 +160,22 @@ df_no_pac = compute_features(signal_no_pac, fs, f_beta, center_extrema='T',
 
 ####################################################################################################
 
-# voltage amplitude
-plt.figure(figsize=(5, 5))
-plt.hist(df_pac['volt_amp'], bins=np.arange(0, 8, .1),
-         color='C0', alpha=.5, label='PAC')
-plt.hist(df_spurious['volt_amp'], bins=np.arange(0, 8, .1),
-         color='C1', alpha=.5, label='spurious')
-plt.hist(df_no_pac['volt_amp'], bins=np.arange(0, 8, .1),
-         color='C2', alpha=.5, label='no PAC')
-plt.xticks(np.arange(5), size=12)
-plt.legend(fontsize=15)
-plt.yticks(size=12)
-plt.xlim((0, 4.5))
-plt.xlabel('Cycle amplitude (mV)', size=15)
-plt.ylabel('# cycles', size=15)
-plt.tight_layout()
-plt.show()
+fig, axes = plt.subplots(figsize=(15, 15), nrows=2, ncols=2)
 
-# period
-plt.figure(figsize=(5, 5))
-plt.hist(df_pac['period'] / fs * 1000, bins=np.arange(0, 250, 5),
-         color='C0', alpha=.5)
-plt.hist(df_spurious['period'] / fs * 1000, bins=np.arange(0, 250, 5),
-         color='C1', alpha=.5)
-plt.hist(df_no_pac['period'] / fs * 1000, bins=np.arange(0, 250, 5),
-         color='C2', alpha=.5)
-plt.xticks(size=12)
-plt.yticks(size=12)
-plt.xlim((0, 250))
-plt.xlabel('Cycle period (ms)', size=15)
-plt.ylabel('# cycles', size=15)
-plt.tight_layout()
-plt.show()
+for idx, key in enumerate(dfs):
 
-# rise-decay asymmetry
-bins = np.arange(0, 1, .1)
-plt.figure(figsize=(5, 5))
-plt.hist(df_pac['time_rdsym'], bins=bins, color='C0', alpha=.5)
-plt.hist(df_spurious['time_rdsym'], bins=bins, color='C1', alpha=.5)
-plt.hist(df_no_pac['time_rdsym'], bins=bins, color='C2', alpha=.5)
-plt.xticks(size=12)
-plt.yticks(size=12)
-plt.xlim((0, 1))
-plt.xlabel('Rise-decay asymmetry\n(fraction of cycle in rise period)', size=15)
-plt.ylabel('# cycles', size=15)
-plt.tight_layout()
-plt.show()
+    # Rescale periods
+    dfs[key]['period'] = dfs[key]['period'] / fs * 1000
 
-# peak-trough asymmetry
-plt.figure(figsize=(5, 5))
-plt.hist(df_pac['time_ptsym'], bins=bins, color='C0', alpha=.5)
-plt.hist(df_spurious['time_ptsym'], bins=bins, color='C1', alpha=.5)
-plt.hist(df_no_pac['time_ptsym'], bins=bins, color='C2', alpha=.5)
-plt.xticks(size=12)
-plt.yticks(size=12)
-plt.xlim((0, 1))
-plt.xlabel('Peak-trough asymmetry\n(fraction of cycle in peak period)',
-           size=15)
-plt.ylabel('# cycles', size=15)
-plt.tight_layout()
-plt.show()
+    # Plot feature histograms
+    plot_feature_hist(dfs[key], 'volt_amp', only_bursts=False, ax=axes[0][0],
+                      label=titles[idx], xlabel='Cycle amplitude (mV)', )
+
+    plot_feature_hist(dfs[key], 'period', only_bursts=False, ax=axes[0][1],
+                      label=titles[idx], xlabel='Cycle period (ms)')
+
+    plot_feature_hist(dfs[key], 'time_rdsym', only_bursts=False, ax=axes[1][0],
+                      label=titles[idx], xlabel='Rise-decay asymmetry')
+
+    plot_feature_hist(dfs[key], 'time_ptsym', only_bursts=False, ax=axes[1][1],
+                      label=titles[idx], xlabel='Peak-trough asymmetry')

--- a/examples/plot_pac_feature_distributions.py
+++ b/examples/plot_pac_feature_distributions.py
@@ -1,0 +1,248 @@
+"""
+PAC cycle feature distributions
+===============================
+This example computes the distributions of bycycle for simulated
+phase-amplitude coupling (PAC)
+"""
+
+####################################################################################################
+# Import packages
+# ---------------
+#
+# First let's import the packages we need. This example depends on the
+# pactools simulator to make pac and a spurious pac function from the
+# pactools spurious pac example.
+####################################################################################################
+
+import numpy as np
+import matplotlib.pyplot as plt
+import scipy.signal
+
+from pactools import simulate_pac, Comodulogram
+from pactools.utils.pink_noise import pink_noise
+from pactools.utils.validation import check_random_state
+
+from bycycle.features import compute_features
+
+
+def simulate_spurious_pac(n_points, fs, spike_amp=1.5, spike_fwhm=0.01,
+                          spike_fq=10., spike_interval_jitter=0.2,
+                          random_state=None):
+    """Simulate some spurious phase-amplitude coupling (PAC) with spikes
+
+    References
+    ----------
+    Gerber, E. M., Sadeh, B., Ward, A., Knight, R. T., & Deouell, L. Y. (2016).
+    Non-sinusoidal activity can produce cross-frequency coupling in cortical
+    signals in the absence of functional interaction between neural sources.
+    PloS one, 11(12), e0167351
+    """
+    n_points = int(n_points)
+    fs = float(fs)
+    rng = check_random_state(random_state)
+    # draw the position of the spikes
+    interval_min = 1. / float(spike_fq) * (1. - spike_interval_jitter)
+    interval_max = 1. / float(spike_fq) * (1. + spike_interval_jitter)
+    n_spikes_max = np.int(n_points / fs / interval_min)
+    spike_intervals = rng.uniform(low=interval_min, high=interval_max,
+                                  size=n_spikes_max)
+    spike_positions = np.cumsum(np.int_(spike_intervals * fs))
+    spike_positions = spike_positions[spike_positions < n_points]
+    # build the spike time series, using a convolution
+    spikes = np.zeros(n_points)
+    spikes[spike_positions] = spike_amp
+    # full width at half maximum to standard deviation convertion
+    spike_std = spike_fwhm / (2 * np.sqrt(2 * np.log(2)))
+    spike_shape = scipy.signal.gaussian(M=np.int(spike_std * fs * 10),
+                                        std=spike_std * fs)
+    spikes = scipy.signal.fftconvolve(spikes, spike_shape, mode='same')
+    noise = pink_noise(n_points, slope=1., random_state=random_state)
+    return spikes + noise, spikes
+
+####################################################################################################
+# Simulate pac data
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Now we will use the imported functions to make pac data, spurious pac data
+# and a sine wave with pink noise.
+#
+
+####################################################################################################
+
+
+f_beta = (14, 28)
+trial_len = 40  # seconds
+fs = 200.  # Hz
+high_fq = 80.0  # Hz; carrier frequency
+low_fq = 24.0  # Hz; driver frequency
+low_fq_width = 2.0  # Hz
+
+n_points = int(trial_len * fs)
+noise_level = 0.25
+
+# simulate beta-gamma pac
+signal_pac = simulate_pac(n_points=n_points, fs=fs,
+                          high_fq=high_fq, low_fq=low_fq,
+                          low_fq_width=low_fq_width,
+                          noise_level=noise_level, random_state=99)
+# simulate 10 Hz spiking which couples to about 60 Hz
+signal_spurious_pac, spikes = simulate_spurious_pac(
+    n_points=n_points, fs=fs, spike_amp=1. / noise_level, random_state=999)
+# make a sine wave that is the driver frequency
+low_fq_signal = np.sin(2 * np.pi * low_fq * np.linspace(0, trial_len,
+                                                        n_points))
+# add the sine wave to pink noise to make a control, no pac signal
+signal_no_pac = low_fq_signal + pink_noise(n_points, slope=1.,
+                                           random_state=9999)
+
+####################################################################################################
+# Check comodulogram for PAC
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""
+Now, we will use the tools from pactools to compute the comodulogram which
+is a visualization of phase amplitude coupling. The stronger the driver
+phase couples with a particular frequency, the brighter the color value.
+The pac signal has 24 - 80 Hz pac as designed, the spurious pac has 10 - 60 Hz
+spurious pac and the final signal has no pac, just background noise.
+"""
+####################################################################################################
+
+fig, axs = plt.subplots(nrows=3, figsize=(10, 12), sharex=True)
+for signal, ax in zip((signal_pac, signal_spurious_pac, signal_no_pac), axs):
+    # check PAC within only channel; high and low sig are the same-- channel i
+    # use the duprelatour driven autoregressive model to fit the data
+    estimator = Comodulogram(fs=fs, low_fq_range=np.arange(1, 41),
+                             low_fq_width=2., method='duprelatour',
+                             progress_bar=True)
+    # compute the comodulogram
+    estimator.fit(signal)
+    # plot the results
+    estimator.plot(axs=[ax], tight_layout=False)
+plt.show()
+
+####################################################################################################
+#
+# Plot time series for each recording
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Now let's see how each signal looks in time. The third plot of spikes is
+# added to pink noise to make the second plot which is the spurious pac.
+# This is so that where the spikes occur can be noted in the spurious pac plot.
+#
+
+####################################################################################################
+
+# plot the signal and the spikes
+n_points_plot = np.int(fs)
+time = np.arange(n_points_plot) / fs
+fig, axs = plt.subplots(nrows=4, figsize=(10, 12), sharex=True)
+axs[0].plot(time, signal_pac[:n_points_plot], color='C0')
+axs[0].set(title='Signal with PAC', ylabel=r'$\mu V$')
+axs[1].plot(time, signal_spurious_pac[:n_points_plot], color='C1')
+axs[1].set(title='Signal with Spurious PAC', ylabel=r'$\mu V$')
+axs[2].plot(time, spikes[:n_points_plot], color='C3')
+axs[2].set(title='Spikes', ylabel=r'$\mu V$')
+axs[3].plot(time, signal_no_pac[:n_points_plot], color='C2')
+axs[3].set(xlabel='Time (sec)', title='Signal with no PAC', ylabel=r'$\mu V$')
+plt.show()
+
+####################################################################################################
+# Compute cycle-by-cycle features
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Here we use the bycycle compute_features function to compute the cycle-by-
+# cycle features of the three signals.
+#
+
+####################################################################################################
+
+# Set parameters for defining oscillatory bursts
+osc_kwargs = {'amplitude_fraction_threshold': 0.3,
+              'amplitude_consistency_threshold': 0.4,
+              'period_consistency_threshold': 0.5,
+              'monotonicity_threshold': 0.8,
+              'n_cycles_min': 3}
+
+# Cycle-by-cycle analysis
+df_pac = compute_features(signal_pac, fs, f_beta, center_extrema='T',
+                          burst_detection_kwargs=osc_kwargs)
+
+df_spurious = compute_features(signal_spurious_pac, fs, f_beta,
+                               center_extrema='T',
+                               burst_detection_kwargs=osc_kwargs)
+
+df_no_pac = compute_features(signal_no_pac, fs, f_beta, center_extrema='T',
+                             burst_detection_kwargs=osc_kwargs)
+
+
+####################################################################################################
+#
+# Plot feature distributions
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# As shown in the feature distributions, the pac signal displays some peak-
+# tough asymmetry as does the spurious pac signal.
+#
+
+####################################################################################################
+
+# voltage amplitude
+plt.figure(figsize=(5, 5))
+plt.hist(df_pac['volt_amp'], bins=np.arange(0, 8, .1),
+         color='C0', alpha=.5, label='PAC')
+plt.hist(df_spurious['volt_amp'], bins=np.arange(0, 8, .1),
+         color='C1', alpha=.5, label='spurious')
+plt.hist(df_no_pac['volt_amp'], bins=np.arange(0, 8, .1),
+         color='C2', alpha=.5, label='no PAC')
+plt.xticks(np.arange(5), size=12)
+plt.legend(fontsize=15)
+plt.yticks(size=12)
+plt.xlim((0, 4.5))
+plt.xlabel('Cycle amplitude (mV)', size=15)
+plt.ylabel('# cycles', size=15)
+plt.tight_layout()
+plt.show()
+
+# period
+plt.figure(figsize=(5, 5))
+plt.hist(df_pac['period'] / fs * 1000, bins=np.arange(0, 250, 5),
+         color='C0', alpha=.5)
+plt.hist(df_spurious['period'] / fs * 1000, bins=np.arange(0, 250, 5),
+         color='C1', alpha=.5)
+plt.hist(df_no_pac['period'] / fs * 1000, bins=np.arange(0, 250, 5),
+         color='C2', alpha=.5)
+plt.xticks(size=12)
+plt.yticks(size=12)
+plt.xlim((0, 250))
+plt.xlabel('Cycle period (ms)', size=15)
+plt.ylabel('# cycles', size=15)
+plt.tight_layout()
+plt.show()
+
+# rise-decay asymmetry
+bins = np.arange(0, 1, .1)
+plt.figure(figsize=(5, 5))
+plt.hist(df_pac['time_rdsym'], bins=bins, color='C0', alpha=.5)
+plt.hist(df_spurious['time_rdsym'], bins=bins, color='C1', alpha=.5)
+plt.hist(df_no_pac['time_rdsym'], bins=bins, color='C2', alpha=.5)
+plt.xticks(size=12)
+plt.yticks(size=12)
+plt.xlim((0, 1))
+plt.xlabel('Rise-decay asymmetry\n(fraction of cycle in rise period)', size=15)
+plt.ylabel('# cycles', size=15)
+plt.tight_layout()
+plt.show()
+
+# peak-trough asymmetry
+plt.figure(figsize=(5, 5))
+plt.hist(df_pac['time_ptsym'], bins=bins, color='C0', alpha=.5)
+plt.hist(df_spurious['time_ptsym'], bins=bins, color='C1', alpha=.5)
+plt.hist(df_no_pac['time_ptsym'], bins=bins, color='C2', alpha=.5)
+plt.xticks(size=12)
+plt.yticks(size=12)
+plt.xlim((0, 1))
+plt.xlabel('Peak-trough asymmetry\n(fraction of cycle in peak period)',
+           size=15)
+plt.ylabel('# cycles', size=15)
+plt.tight_layout()
+plt.show()

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -9,3 +9,5 @@ sphinx-copybutton
 neurodsp >= 2.0.0
 pillow
 seaborn
+mne
+pactools

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -11,3 +11,4 @@ pillow
 seaborn
 mne
 pactools
+scikit-learn


### PR DESCRIPTION
It might be helpful to mne-python users to have an example of an interface with bycycle as in this example for a [pac toolbox](https://pactools.github.io/auto_examples/plot_mne_epoch_masking.html). I also added a bit out of curiosity using the pac simulation for both pac simulated as expected and "spurious" pac caused by spiking. The peak-trough asymmetry is lower in both the particular example of pac and spurious pac compared to a sine wave with pink noise while rise-decay asymmetry is closer to the same for all three but a bit skewed positive for spurious pac. I think this means it's working reasonably well? If the spurious pac spike amplitude gets increased, the same trend holds while it just looks like a spike train. I'm not entirely sure how to interpret this, maybe someone can comment.

A simple mne-python interface might be more useful in which case I can pare all this down significantly (or none at all in which case, totally fine to close without merging). I thought this might be useful and it's helped me understand the pac-asymmetry feature relationship a bit better. It would be great to know how to make it easier to understand/interpret though if anyone has any input.