### PR TITLE
Add requirements.txt to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include requirements.txt


### PR DESCRIPTION
It looks you can't build this package from source since the `setup.py` fails since the `requirements.txt` isn't included in the source distribution. This PR adds the file to the `MANIFEST.in`