### PR TITLE
[BUG] Monotonicity Warning

### DIFF
--- a/bycycle/features/burst.py
+++ b/bycycle/features/burst.py
@@ -200,12 +200,12 @@ def compute_monotonicity(df_samples, sig):
     for idx, row in df_samples.iterrows():
 
         if 'sample_peak' in df_samples.columns:
-            rise_period = sig[int(row['sample_last_trough']):int(row['sample_peak'])]
-            decay_period = sig[int(row['sample_peak']):int(row['sample_next_trough'])]
+            rise_period = sig[int(row['sample_last_trough']):int(row['sample_peak'])+1]
+            decay_period = sig[int(row['sample_peak']):int(row['sample_next_trough'])+1]
 
         else:
-            decay_period = sig[int(row['sample_last_peak']):int(row['sample_trough'])]
-            rise_period = sig[int(row['sample_trough']):int(row['sample_next_peak'])]
+            decay_period = sig[int(row['sample_last_peak']):int(row['sample_trough'])+1]
+            rise_period = sig[int(row['sample_trough']):int(row['sample_next_peak'])+1]
 
         decay_mono = np.mean(np.diff(decay_period) < 0)
         rise_mono = np.mean(np.diff(rise_period) > 0)

--- a/bycycle/features/burst.py
+++ b/bycycle/features/burst.py
@@ -131,17 +131,31 @@ def compute_amp_consistency(df_shape_features, df_samples):
 
     for cyc in range(1, cycles-1):
 
-        consist_current = np.min([rises[cyc], decays[cyc]]) / np.max([rises[cyc], decays[cyc]])
+        # Division by zero will return np.nan, supress warning.
+        with np.errstate(invalid='ignore', divide='ignore'):
 
-        if 'sample_peak' in df_samples.columns:
-            consist_last = np.min([rises[cyc], decays[cyc-1]]) / np.max([rises[cyc], decays[cyc-1]])
-            consist_next = np.min([rises[cyc+1], decays[cyc]]) / np.max([rises[cyc+1], decays[cyc]])
+            consist_current = np.min([rises[cyc], decays[cyc]]) / np.max([rises[cyc], decays[cyc]])
 
-        else:
-            consist_last = np.min([rises[cyc-1], decays[cyc]]) / np.max([rises[cyc-1], decays[cyc]])
-            consist_next = np.min([rises[cyc], decays[cyc+1]]) / np.max([rises[cyc], decays[cyc+1]])
+            if 'sample_peak' in df_samples.columns:
 
-        amp_consistency[cyc] = np.min([consist_current, consist_next, consist_last])
+                consist_last = np.min([rises[cyc], decays[cyc-1]]) / \
+                    np.max([rises[cyc], decays[cyc-1]])
+
+                consist_next = np.min([rises[cyc+1], decays[cyc]]) / \
+                    np.max([rises[cyc+1], decays[cyc]])
+
+            else:
+
+                consist_last = np.min([rises[cyc-1], decays[cyc]]) / \
+                    np.max([rises[cyc-1], decays[cyc]])
+
+                consist_next = np.min([rises[cyc], decays[cyc+1]]) / \
+                    np.max([rises[cyc], decays[cyc+1]])
+
+            if np.isnan([consist_current, consist_next, consist_last]).all():
+                amp_consistency[cyc] = np.nan
+            else:
+                amp_consistency[cyc] = np.nanmin([consist_current, consist_next, consist_last])
 
     return amp_consistency
 


### PR DESCRIPTION
This is related to #42. The issue involved warnings when computing monotonicity. This occurred when `sample_last_trough` and `sample_peak` (or `sample_peak` and `sample_next_trough` for decay periods) are adjacent. This should be fixed be adding one to the end slice index. The `rise_period` should include the start/end point, otherwise the segments directly to the left/right of the peak are left out when taking the np.diff of the rise and decay periods. Here is sample code to reproduce the warning:

```
import numpy as np
from neurodsp.filt import filter_signal
from bycycle.plts import plot_burst_detect_summary
from bycycle.features import compute_features

sigs = np.load('tutorials/data/sim_experiment.npy')
sig = sigs[0]
fs = 1000
sig = filter_signal(sig, fs, 'lowpass', 30, n_seconds=.2, remove_edges=False)

threshold_kwargs = {'amp_fraction_threshold': .2,
                    'amp_consistency_threshold': .5,
                    'period_consistency_threshold': .5,
                    'monotonicity_threshold': .8,
                    'min_n_cycles': 3}

df_features, df_samples = compute_features(sig, fs, (7, 13), threshold_kwargs=threshold_kwargs)

# Plot the cycle that raises the warning
print(f'Samples to seconds: \n{df_samples.iloc[25] / fs}\n')

plot_burst_detect_summary(df_features, df_samples, sig, fs, threshold_kwargs,
                          plot_only_result=True, xlim=(2.768, 2.8))


print(f'{df_samples.iloc[25]}\n')
rise_period = sig[2769:2770]
print(rise_period) # diff of a single value is an empty array

rise_mono = np.mean(np.diff(rise_period) > 0) # mean of an empty array raises the warning
```