### PR TITLE
[BUG] Zerox off-by-one

### DIFF
--- a/bycycle/cyclepoints/zerox.py
+++ b/bycycle/cyclepoints/zerox.py
@@ -75,7 +75,7 @@ def find_flank_zerox(sig, flank):
     """
 
     assert flank in ['rise', 'decay']
-    pos = sig < 0 if flank == 'rise' else sig > 0
+    pos = sig <= 0 if flank == 'rise' else sig >= 0
 
     zero_xs = (pos[:-1] & ~pos[1:]).nonzero()[0]
 

--- a/bycycle/cyclepoints/zerox.py
+++ b/bycycle/cyclepoints/zerox.py
@@ -75,7 +75,7 @@ def find_flank_zerox(sig, flank):
     """
 
     assert flank in ['rise', 'decay']
-    pos = sig <= 0 if flank == 'rise' else sig >= 0
+    pos = sig <= 0 if flank == 'rise' else sig > 0
 
     zero_xs = (pos[:-1] & ~pos[1:]).nonzero()[0]
 


### PR DESCRIPTION
Whenever a signal has an exact zero-crossing, there would be an off-by-one error. This PR fixes this.

```
import numpy as np
from neurodsp.plts import plot_time_series
from neurodsp.sim import sim_oscillation
from bycycle.cyclepoints import find_extrema
from bycycle.cyclepoints.zerox import find_zerox, find_flank_zerox

fs, f_range = 500, (8, 12)
sig = sim_oscillation(.5, fs, 10)
sig = np.round(sig, decimals=3)
sig[:50] = 0.0
sig[-50:] = 0.0

times = np.arange(0, len(sig)/fs, 1/fs)

rises_flank = find_flank_zerox(sig, 'rise')
peaks, troughs = find_extrema(sig, fs, f_range, boundary=0)
rises, decays = find_zerox(sig, peaks, troughs)

plot_time_series([times, times[rises_flank], times], [sig, sig[rises_flank], [0]*len(sig)], 
                 title='Rise zerox from find_flank_zerox', ls=["solid", "", 'dashed'],
                 marker=['', 'o', ''], alpha=[1, 1, .5])

plot_time_series([times, times[rises], times], [sig, sig[rises], [0]*len(sig)],
                 title='Rise zerox from find_zerox', ls=["solid", "", 'dashed'], 
                 marker=['', 'o', ''], alpha=[1, 1, .5])

print(sig[rises[0]]) # not a zerox
print(sig[rises[0]+1]) # one off error
```
Before this PR:
![pre_flank](https://user-images.githubusercontent.com/34786005/90182090-47d89380-dd66-11ea-96da-10fde576c125.png)
![pre_zerox](https://user-images.githubusercontent.com/34786005/90182098-49a25700-dd66-11ea-8584-582e3db4f65a.png)

And after:
![post_flank](https://user-images.githubusercontent.com/34786005/90182121-53c45580-dd66-11ea-9df2-75bcc240dbf4.png)
![post_zerox](https://user-images.githubusercontent.com/34786005/90182130-54f58280-dd66-11ea-8b60-8e614cc552b2.png)

