### PR TITLE
[WIP/DOC] Multi-version docsite

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,6 +6,8 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = bycycle
 SOURCEDIR     = .
 BUILDDIR      = _build
+STABLE 		  = v0.1.3
+DEVELOPMENT   = v1.0.0rc
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -52,32 +54,38 @@ install:
 	git commit -a -m 'Make install' && \
 	git push
 
-
 # Build multiple versions
 html-multi:
-	# Ensure each tag is a branch prior to running, example:
-	#   git branch v0.1.3 0.1.3
-
 	# Clean out existing build
 	make clean
-
-	# Setup html directory
-	mkdir -p _build/html_tmp
-
-	# Add versions to build here (must start with 'v')
-	for v in v0.1.3 v1.0.0rc; do \
-		mkdir -p _build/html_tmp/$$v; \
+	# Ensure navbar template exists
+	orig_branch=`git branch --show-current`
+	git checkout $(STABLE)
+	if [ ! -f _templates/navbar.html ]; then \
+		git checkout $(DEVELOPMENT) _templates/navbar.html -3; \
+		git commit -m "navbar updated"; \
+	fi
+	# Create the stable site
+	make html
+	# Cleanup stable build
+	rm -rf _build/doctrees
+	rm -rf auto_examples
+	rm -rf auto_tutorials
+	rm -rf generated
+	mv _build/* _build/html_stable
+	# Add versions to build here
+	for v in $(DEVELOPMENT); do \
 		git checkout $$v; \
 		make html; \
+		mkdir -p _build/html_stable/$$v; \
+		mv _build/html/* _build/html_stable/$$v; \
 		rm -rf auto_examples; \
 		rm -rf auto_tutorials; \
 		rm -rf generated; \
 		rm -rf _build/doctrees; \
-		mv _build/html/* _build/html_tmp/$$v; \
 		rm -rf _build/html; \
 	done
-
-	# Finalize the tmp directory
-	mv _build/html_tmp _build/html
-
-
+	# Move stable back to root reference
+	mv _build/html_stable _build/html
+	mkdir _build/html/$(STABLE)
+	cp _build/html/index.html _build/html/$(STABLE)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,8 +6,9 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = bycycle
 SOURCEDIR     = .
 BUILDDIR      = _build
-STABLE        = v0.1.3
-DEVELOPMENT   = v1.0.0rc
+STABLE        = 0.1.3
+DEVELOPMENT   = 1.0.0rc1
+RECENT		  = ""
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -57,35 +58,61 @@ install:
 # Build multiple versions
 html-multi:
 	# Clean out existing build
+	$(eval current_branch := $(shell git branch -l | grep "\*" | sed "s/.* //" ))
 	make clean
+	# Create clean remote
+	git remote remove upstream_temp || true
+	git remote add upstream_temp https://github.com/bycycle-tools/bycycle.git
+	git fetch upstream_temp --tags
+	# Create clean branches
+	git branch -D v$(STABLE) || true
+	git branch v$(STABLE) tags/$(STABLE)
+	git branch -D v$(DEVELOPMENT) || true
+	git branch v$(DEVELOPMENT) tags/$(DEVELOPMENT)
+	# Delete below after mergings PRs
+	git remote remove ryan || true
+	git remote add ryan https://github.com/ryanhammonds/bycycle.git
+	git fetch ryan parallel
+	git fetch ryan doc
+	git checkout v$(DEVELOPMENT)
+	git merge ryan/parallel ryan/doc -m "merge open prs"
+	# Checkout the stable release tag
+	git checkout v$(STABLE)
 	# Ensure navbar template exists
-	git checkout $(STABLE)
 	if [ ! -f _templates/navbar.html ]; then \
-		git checkout $(DEVELOPMENT) _templates/navbar.html -3; \
+		git checkout v$(DEVELOPMENT) _templates/navbar.html -3; \
 		git commit -m "navbar updated"; \
 	fi
 	# Create the stable site
 	make html
-	# Cleanup stable build
 	rm -rf _build/doctrees
 	rm -rf auto_examples
 	rm -rf auto_tutorials
 	rm -rf generated
 	mv _build/* _build/html_stable
-	# Add versions to build here
-	for v in $(DEVELOPMENT); do \
-		git checkout $$v; \
+	git checkout $(current_branch)
+	git branch -D v$(STABLE)
+	# Build develompent and recent sites
+	$(eval BUILDS := $(DEVELOPMENT) $(RECENT))
+	for v in $(BUILDS); do \
+		if [ -z $$v ]; then continue; fi; \
+		if [ $$v = $(DEVELOPMENT) ]; then git branch -D v$$v || true; git branch v$$v tags/$$v; fi;\
+		git checkout v$$v; \
 		make html; \
-		mkdir -p _build/html_stable/$$v; \
-		mv _build/html/* _build/html_stable/$$v; \
+		mkdir -p _build/html_stable/v$$v; \
+		mv _build/html/* _build/html_stable/v$$v; \
 		rm -rf auto_examples; \
 		rm -rf auto_tutorials; \
 		rm -rf generated; \
 		rm -rf _build/doctrees; \
 		rm -rf _build/html; \
+		git checkout $(current_branch);\
+		git branch -D v$$v; \
 	done
 	# Move stable back to root reference
 	mv _build/html_stable _build/html
+	# Remove the temporary remote
+	git remote remove upstream_temp
 
 # Build the multi-version html site, and push it to gh-pages branch of repo to deploy
 install-multi:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -89,3 +89,25 @@ html-multi:
 	mv _build/html_stable _build/html
 	mkdir _build/html/$(STABLE)
 	cp _build/html/index.html _build/html/$(STABLE)
+
+# Build the multi-version html site, and push it to gh-pages branch of repo to deploy
+install-multi:
+	# Clean out existing build
+	make clean
+	# Clone, specifically, the gh-pages branch, putting it into '_build/gh_pages/'
+	#   --no-checkout just fetches the root folder without content
+	#   --depth 1 is a speed optimization since we don't need the history prior to the last commit
+	#   -b gh-pages fetches only the branch for the gh-pages
+	git clone -b gh-pages --single-branch --no-checkout --depth 1 https://github.com/bycycle-tools/bycycle _build/gh_pages
+	# A .nojekyll file tells Github pages to bypass Jekyll processing
+	touch _build/gh_pages/.nojekyll
+	# Build the sphinx site
+	make html-multi
+	# Copy site into the gh-pages branch folder, then push to Github to deploy
+	cd _build/ && \
+	cp -r html/ gh_pages && \
+	cd gh_pages && \
+	git add * && \
+	git add .nojekyll && \
+	git commit -a -m 'Make install' && \
+	git push

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -47,7 +47,7 @@ install:
 	make html
 	# Copy site into the gh-pages branch folder, then push to Github to deploy
 	cd _build/ && \
-	cp -r html/ gh_pages && \
+	cp -r html/* gh_pages && \
 	cd gh_pages && \
 	git add * && \
 	git add .nojekyll && \
@@ -59,7 +59,6 @@ html-multi:
 	# Clean out existing build
 	make clean
 	# Ensure navbar template exists
-	orig_branch=`git branch --show-current`
 	git checkout $(STABLE)
 	if [ ! -f _templates/navbar.html ]; then \
 		git checkout $(DEVELOPMENT) _templates/navbar.html -3; \
@@ -87,13 +86,13 @@ html-multi:
 	done
 	# Move stable back to root reference
 	mv _build/html_stable _build/html
-	mkdir _build/html/$(STABLE)
-	cp _build/html/index.html _build/html/$(STABLE)
 
 # Build the multi-version html site, and push it to gh-pages branch of repo to deploy
 install-multi:
 	# Clean out existing build
 	make clean
+	# Build the sphinx site
+	make html-multi
 	# Clone, specifically, the gh-pages branch, putting it into '_build/gh_pages/'
 	#   --no-checkout just fetches the root folder without content
 	#   --depth 1 is a speed optimization since we don't need the history prior to the last commit
@@ -101,11 +100,9 @@ install-multi:
 	git clone -b gh-pages --single-branch --no-checkout --depth 1 https://github.com/bycycle-tools/bycycle _build/gh_pages
 	# A .nojekyll file tells Github pages to bypass Jekyll processing
 	touch _build/gh_pages/.nojekyll
-	# Build the sphinx site
-	make html-multi
 	# Copy site into the gh-pages branch folder, then push to Github to deploy
-	cd _build/ && \
-	cp -r html/ gh_pages && \
+	cd _build && \
+	cp -r html/* gh_pages && \
 	cd gh_pages && \
 	git add * && \
 	git add .nojekyll && \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -51,3 +51,33 @@ install:
 	git add .nojekyll && \
 	git commit -a -m 'Make install' && \
 	git push
+
+
+# Build multiple versions
+html-multi:
+	# Ensure each tag is a branch prior to running, example:
+	#   git branch v0.1.3 0.1.3
+
+	# Clean out existing build
+	make clean
+
+	# Setup html directory
+	mkdir -p _build/html_tmp
+
+	# Add versions to build here (must start with 'v')
+	for v in v0.1.3 v1.0.0rc; do \
+		mkdir -p _build/html_tmp/$$v; \
+		git checkout $$v; \
+		make html; \
+		rm -rf auto_examples; \
+		rm -rf auto_tutorials; \
+		rm -rf generated; \
+		rm -rf _build/doctrees; \
+		mv _build/html/* _build/html_tmp/$$v; \
+		rm -rf _build/html; \
+	done
+
+	# Finalize the tmp directory
+	mv _build/html_tmp _build/html
+
+

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,7 +8,7 @@ SOURCEDIR     = .
 BUILDDIR      = _build
 STABLE        = 0.1.3
 DEVELOPMENT   = 1.0.0rc1
-RECENT		  = ""
+RECENT        = ""
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -85,10 +85,7 @@ html-multi:
 	fi
 	# Create the stable site
 	make html
-	rm -rf _build/doctrees
-	rm -rf auto_examples
-	rm -rf auto_tutorials
-	rm -rf generated
+	rm -rf _build/doctrees auto_examples auto_tutorials generated
 	mv _build/* _build/html_stable
 	git checkout $(current_branch)
 	git branch -D v$(STABLE)
@@ -101,11 +98,7 @@ html-multi:
 		make html; \
 		mkdir -p _build/html_stable/v$$v; \
 		mv _build/html/* _build/html_stable/v$$v; \
-		rm -rf auto_examples; \
-		rm -rf auto_tutorials; \
-		rm -rf generated; \
-		rm -rf _build/doctrees; \
-		rm -rf _build/html; \
+		rm -rf auto_examples auto_tutorials generated _build/doctrees _build/html; \
 		git checkout $(current_branch);\
 		git branch -D v$$v; \
 	done

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -75,7 +75,8 @@ html-multi:
 	git fetch ryan parallel
 	git fetch ryan doc
 	git checkout v$(DEVELOPMENT)
-	git merge ryan/parallel ryan/doc -m "merge open prs"
+	git merge ryan/parallel -m "merge open prs"
+	git merge ryan/doc -m "merge open prs"
 	# Checkout the stable release tag
 	git checkout v$(STABLE)
 	# Ensure navbar template exists
@@ -93,7 +94,7 @@ html-multi:
 	$(eval BUILDS := $(DEVELOPMENT) $(RECENT))
 	for v in $(BUILDS); do \
 		if [ -z $$v ]; then continue; fi; \
-		if [ $$v = $(DEVELOPMENT) ]; then git branch -D v$$v || true; git branch v$$v tags/$$v; fi;\
+		if [ ! $$v = $(DEVELOPMENT) ]; then git branch -D v$$v || true; git branch v$$v tags/$$v; fi;\
 		git checkout v$$v; \
 		make html; \
 		mkdir -p _build/html_stable/v$$v; \

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = bycycle
 SOURCEDIR     = .
 BUILDDIR      = _build
-STABLE 		  = v0.1.3
+STABLE        = v0.1.3
 DEVELOPMENT   = v1.0.0rc
 
 # Put it first so that "make" without argument is like "make help".

--- a/doc/_templates/navbar.html
+++ b/doc/_templates/navbar.html
@@ -8,8 +8,8 @@
               <span class="caret"></span>
             </button>
               <ul class="dropdown-menu" aria-labelledby="dLabelMore">
-                <li><a href="https://bycycle-tools.github.io/bycycle/v1.0.0rc/index.html">v.1.0.0rc</a></li>
-                <li><a href="https://bycycle-tools.github.io/bycycle/index.html">v0.1.3 (stable)</a></li>
+                <li><a href="https://bycycle-tools.github.io/bycycle/v1.0.0rc/index.html">v1.0.0rc</a></li>
+                <li><a href="https://bycycle-tools.github.io/bycycle/index.html">v0.1.3(stable)</a></li>
               </ul>
             </li>
 {% endblock %}

--- a/doc/_templates/navbar.html
+++ b/doc/_templates/navbar.html
@@ -9,7 +9,7 @@
             </button>
               <ul class="dropdown-menu" aria-labelledby="dLabelMore">
                 <li><a href="https://bycycle-tools.github.io/bycycle/v1.0.0rc/index.html">v.1.0.0rc</a></li>
-                <li><a href="https://bycycle-tools.github.io/bycycle/v0.1.3/index.html">v0.1.3 (stable)</a></li>
+                <li><a href="https://bycycle-tools.github.io/bycycle/index.html">v0.1.3 (stable)</a></li>
               </ul>
             </li>
 {% endblock %}

--- a/doc/_templates/navbar.html
+++ b/doc/_templates/navbar.html
@@ -1,0 +1,15 @@
+
+{% extends "!navbar.html" %}
+
+{% block navbartoc %}
+            <li class="dropdown">
+              <button type="button" class="btn btn-{% if (build_dev_html|tobool) %}danger{% else %}primary{% endif %} btn-sm navbar-btn dropdown-toggle" id="dLabelMore" data-toggle="dropdown" style="margin-left: 10px">
+              v{{ release }}
+              <span class="caret"></span>
+            </button>
+              <ul class="dropdown-menu" aria-labelledby="dLabelMore">
+                <li><a href="https://bycycle-tools.github.io/bycycle/v1.0.0rc/index.html">v.1.0.0rc</a></li>
+                <li><a href="https://bycycle-tools.github.io/bycycle/v0.1.3/index.html">v0.1.3 (stable)</a></li>
+              </ul>
+            </li>
+{% endblock %}


### PR DESCRIPTION
This allows multiple versions of documentation to be hosted on the gh-pages sites. Currently, `make html-multi` may be ran to build the local version. I'll need to implement a `make install-multi` so it will be pushed to the gh-pages branch (this may take some trial and error). Different versions may be navigated via a dropdown menu:

![multiverions_navbar](https://user-images.githubusercontent.com/34786005/96201816-6b5cbd80-0f12-11eb-8c3c-e62d05ac698e.png)
 