### PR TITLE
[ENH] 2d/3d Array Improvement

### DIFF
--- a/bycycle/burst/amp.py
+++ b/bycycle/burst/amp.py
@@ -31,8 +31,8 @@ def detect_bursts_amp(df_features, burst_fraction_threshold=1, min_n_cycles=3):
     >>> from neurodsp.sim import sim_bursty_oscillation
     >>> fs = 500
     >>> sig = sim_bursty_oscillation(10, fs, freq=10)
-    >>> df_shapes, df_samples = compute_shape_features(sig, fs, f_range=(8, 12))
-    >>> df_burst = compute_burst_features(df_shapes, df_samples, sig, burst_method='amp',
+    >>> df_shapes = compute_shape_features(sig, fs, f_range=(8, 12))
+    >>> df_burst = compute_burst_features(df_shapes, sig, burst_method='amp',
     ...                                   burst_kwargs={'fs': fs, 'f_range': (8, 12)})
     >>> df_burst = detect_bursts_amp(df_burst)
     """

--- a/bycycle/burst/cycle.py
+++ b/bycycle/burst/cycle.py
@@ -71,8 +71,8 @@ def detect_bursts_cycles(df_features, amp_fraction_threshold=0., amp_consistency
     >>> from neurodsp.sim import sim_bursty_oscillation
     >>> fs = 500
     >>> sig = sim_bursty_oscillation(10, fs, freq=10)
-    >>> df_shapes, df_samples = compute_shape_features(sig, fs, f_range=(8, 12))
-    >>> df_burst = compute_burst_features(df_shapes, df_samples, sig)
+    >>> df_shapes = compute_shape_features(sig, fs, f_range=(8, 12))
+    >>> df_burst = compute_burst_features(df_shapes, sig)
     >>> df_burst = detect_bursts_cycles(df_burst)
     """
 

--- a/bycycle/burst/utils.py
+++ b/bycycle/burst/utils.py
@@ -4,8 +4,8 @@ from copy import deepcopy
 import numpy as np
 from bycycle.utils.checks import check_param
 
-###################################################################################################
-###################################################################################################
+####################################################################################################
+####################################################################################################
 
 def check_min_burst_cycles(is_burst, min_n_cycles=3):
     """Enforce minimum number of consecutive cycles to be considered a burst.
@@ -86,7 +86,8 @@ def recompute_edges(df_features, threshold_kwargs):
     >>> threshold_kwargs = {'amp_fraction_threshold': 0., 'amp_consistency_threshold': .5,
     ...                     'period_consistency_threshold': .5, 'monotonicity_threshold': .4,
     ...                     'min_n_cycles': 3}
-    >>> df_features = compute_features(sig, fs=1000, f_range=(8, 12), threshold_kwargs=threshold_kwargs)
+    >>> df_features = compute_features(sig, fs=1000, f_range=(8, 12),
+    ...                                threshold_kwargs=threshold_kwargs)
     >>> threshold_kwargs['amp_consistency_threshold'] = 0
     >>> df_features_edges = recompute_edges(df_features, threshold_kwargs)
     """
@@ -107,7 +108,7 @@ def recompute_edges(df_features, threshold_kwargs):
                             enumerate(burst_edges)])
 
     # Recompute is_burst
-    df_features_edges =  detect_bursts_cycles(
+    df_features_edges = detect_bursts_cycles(
         df_features_edges,
         amp_fraction_threshold=threshold_kwargs['amp_fraction_threshold'],
         amp_consistency_threshold=threshold_kwargs['amp_consistency_threshold'],

--- a/bycycle/burst/utils.py
+++ b/bycycle/burst/utils.py
@@ -79,12 +79,14 @@ def recompute_edges(df_features, threshold_kwargs):
     --------
     Lower the amplitude consistency threshold to zero for cycles on the edges of bursts:
 
+    >>> from neurodsp.sim import sim_combined
+    >>> from bycycle.features import compute_features
     >>> sig = sim_combined(n_seconds=4, fs=1000, components={'sim_bursty_oscillation': {'freq': 10},
     ...                                                      'sim_powerlaw': {'exp': 2}})
     >>> threshold_kwargs = {'amp_fraction_threshold': 0., 'amp_consistency_threshold': .5,
     ...                     'period_consistency_threshold': .5, 'monotonicity_threshold': .4,
     ...                     'min_n_cycles': 3}
-    >>> df_features, _ = compute_features(sig, fs=1000, f_range=(8, 12), threshold_kwargs=threshold_kwargs)
+    >>> df_features = compute_features(sig, fs=1000, f_range=(8, 12), threshold_kwargs=threshold_kwargs)
     >>> threshold_kwargs['amp_consistency_threshold'] = 0
     >>> df_features_edges = recompute_edges(df_features, threshold_kwargs)
     """

--- a/bycycle/features/burst.py
+++ b/bycycle/features/burst.py
@@ -133,8 +133,7 @@ def compute_amp_consistency(df_shape_features):
     Parameters
     ----------
     df_shape_features : pandas.DataFrame
-        Shape features for each cycle, determined using :func:`~.compute_shape_features` with
-        ``return_samples=True``.
+        Shape features for each cycle, determined using :func:`~.compute_shape_features`.
     df_samples : pandas.DataFrame
         Indices of cyclepoints returned from :func:`~.compute_cyclepoints`.
 
@@ -142,10 +141,6 @@ def compute_amp_consistency(df_shape_features):
     -------
     amp_consist : 1d array
         The amplitude consistency of each cycle.
-
-    Notes
-    -----
-    This function requires the input dataframe to contain sample indices of cyclepoints.
 
     Examples
     --------
@@ -243,7 +238,7 @@ def compute_monotonicity(df_samples, sig):
 
     Parameters
     ----------
-    df_samples: pandas.DataFrame
+    df_samples : pandas.DataFrame
         Indices of cyclepoints returned from :func:`~.compute_cyclepoints`.
     sig : 1d array
         Time series.

--- a/bycycle/features/burst.py
+++ b/bycycle/features/burst.py
@@ -9,16 +9,13 @@ from bycycle.burst import detect_bursts_dual_threshold
 ###################################################################################################
 ###################################################################################################
 
-def compute_burst_features(df_shape_features, df_samples, sig,
-                           burst_method='cycles', burst_kwargs=None):
+def compute_burst_features(df_shape_features, sig, burst_method='cycles', burst_kwargs=None):
     """Compute burst features for each cycle.
 
     Parameters
     ----------
     df_shape_features : pandas.DataFrame
         Shape parameters for each cycle, determined using :func:`~.compute_shape_features`.
-    df_samples : pandas.DataFrame
-        Indices of cyclepoints returned from :func:`~.compute_cyclepoints`.
     sig : 1d array
         Voltage time series used for determining monotonicity.
     burst_method : string, optional, default: 'cycles'
@@ -63,8 +60,8 @@ def compute_burst_features(df_shape_features, df_samples, sig,
     >>> from neurodsp.sim import sim_bursty_oscillation
     >>> fs  = 500
     >>> sig = sim_bursty_oscillation(10, fs, 10)
-    >>> df_shapes, df_samples = compute_shape_features(sig, fs, f_range=(8, 12))
-    >>> df_burst = compute_burst_features(df_shapes, df_samples, sig, burst_method='amp',
+    >>> df_shapes = compute_shape_features(sig, fs, f_range=(8, 12))
+    >>> df_burst = compute_burst_features(df_shapes, sig, burst_method='amp',
     ...                                   burst_kwargs={'fs': fs, 'f_range': (8, 12)})
     """
 
@@ -78,10 +75,10 @@ def compute_burst_features(df_shape_features, df_samples, sig,
         df_burst_features['amp_fraction'] = compute_amp_fraction(df_shape_features)
 
         df_burst_features['amp_consistency'] = \
-                compute_amp_consistency(df_shape_features, df_samples)
+                compute_amp_consistency(df_shape_features)
 
         df_burst_features['period_consistency'] = compute_period_consistency(df_shape_features)
-        df_burst_features['monotonicity'] = compute_monotonicity(df_samples, sig)
+        df_burst_features['monotonicity'] = compute_monotonicity(df_shape_features, sig)
 
     # Use dual threshold burst detection
     elif burst_method == 'amp':
@@ -94,7 +91,7 @@ def compute_burst_features(df_shape_features, df_samples, sig,
                              "when 'burst_method' is 'amp'.")
 
         df_burst_features['burst_fraction'] = \
-            compute_burst_fraction(df_samples, sig, fs, f_range, **burst_kwargs)
+            compute_burst_fraction(df_shape_features, sig, fs, f_range, **burst_kwargs)
 
     else:
         raise ValueError("Unrecognized 'burst_method'.")
@@ -123,20 +120,21 @@ def compute_amp_fraction(df_shape_features):
     >>> from neurodsp.sim import sim_bursty_oscillation
     >>> fs = 500
     >>> sig = sim_bursty_oscillation(10, fs, freq=10)
-    >>> df_shapes, df_samples = compute_shape_features(sig, fs, (8, 12))
+    >>> df_shapes = compute_shape_features(sig, fs, (8, 12))
     >>> amp_fraction = compute_amp_fraction(df_shapes)
     """
 
     return df_shape_features['volt_amp'].rank() / len(df_shape_features)
 
 
-def compute_amp_consistency(df_shape_features, df_samples):
+def compute_amp_consistency(df_shape_features):
     """Compute amplitude consistency for each cycle.
 
     Parameters
     ----------
     df_shape_features : pandas.DataFrame
-        Shape features for each cycle, determined using :func:`~.compute_shape_features`.
+        Shape features for each cycle, determined using :func:`~.compute_shape_features` with
+        ``return_samples=True``.
     df_samples : pandas.DataFrame
         Indices of cyclepoints returned from :func:`~.compute_cyclepoints`.
 
@@ -144,6 +142,10 @@ def compute_amp_consistency(df_shape_features, df_samples):
     -------
     amp_consist : 1d array
         The amplitude consistency of each cycle.
+
+    Notes
+    -----
+    This function requires the input dataframe to contain sample indices of cyclepoints.
 
     Examples
     --------
@@ -153,8 +155,8 @@ def compute_amp_consistency(df_shape_features, df_samples):
     >>> from neurodsp.sim import sim_bursty_oscillation
     >>> fs = 500
     >>> sig = sim_bursty_oscillation(10, fs, freq=10)
-    >>> df_shapes, df_samples = compute_shape_features(sig, fs, f_range=(8, 12))
-    >>> amp_consistency = compute_amp_consistency(df_shapes, df_samples)
+    >>> df_shapes = compute_shape_features(sig, fs, f_range=(8, 12))
+    >>> amp_consistency = compute_amp_consistency(df_shapes)
     """
 
     # Compute amplitude consistency
@@ -170,7 +172,7 @@ def compute_amp_consistency(df_shape_features, df_samples):
 
             consist_current = np.min([rises[cyc], decays[cyc]]) / np.max([rises[cyc], decays[cyc]])
 
-            if 'sample_peak' in df_samples.columns:
+            if 'sample_peak' in df_shape_features.columns:
 
                 consist_last = np.min([rises[cyc], decays[cyc-1]]) / \
                     np.max([rises[cyc], decays[cyc-1]])
@@ -215,7 +217,7 @@ def compute_period_consistency(df_shape_features):
     >>> from neurodsp.sim import sim_bursty_oscillation
     >>> fs = 500
     >>> sig = sim_bursty_oscillation(10, fs, freq=10)
-    >>> df_shapes, df_samples = compute_shape_features(sig, fs, f_range=(8, 12))
+    >>> df_shapes = compute_shape_features(sig, fs, f_range=(8, 12))
     >>> period_consistency = compute_period_consistency(df_shapes)
     """
 
@@ -241,7 +243,7 @@ def compute_monotonicity(df_samples, sig):
 
     Parameters
     ----------
-    df_samples : pandas.DataFrame
+    df_samples: pandas.DataFrame
         Indices of cyclepoints returned from :func:`~.compute_cyclepoints`.
     sig : 1d array
         Time series.

--- a/bycycle/features/features.py
+++ b/bycycle/features/features.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 
 from bycycle.utils.checks import check_param
+from bycycle.utils.dataframes import drop_samples_df
 from bycycle.features.shape import compute_shape_features
 from bycycle.features.burst import compute_burst_features
 from bycycle.burst import detect_bursts_cycles, detect_bursts_amp
@@ -39,14 +40,14 @@ def compute_features(sig, fs, f_range, center_extrema='peak', burst_method='cycl
 
     burst_kwargs : dict, optional, default: None
         Additional keyword arguments defined in :func:`~.compute_burst_fraction` for dual
-        amplitude threshold burst detection (i.e. when burst_method == 'amp').
+        amplitude threshold burst detection (i.e. when burst_method='amp').
     threshold_kwargs : dict, optional, default: None
         Feature thresholds for cycles to be considered bursts, matching keyword arguments for:
 
         - :func:`~.detect_bursts_cycles` for consistency burst detection
-          (i.e. when burst_method == 'cycles')
+          (i.e. when burst_method='cycles')
         - :func:`~.detect_bursts_amp` for  amplitude threshold burst detection
-          (i.e. when burst_method == 'amp').
+          (i.e. when burst_method='amp').
 
     find_extrema_kwargs : dict, optional, default: None
         Keyword arguments for function to find peaks an troughs (:func:`~.find_extrema`)
@@ -74,7 +75,7 @@ def compute_features(sig, fs, f_range, center_extrema='peak', burst_method='cycl
         - ``time_ptsym`` : fraction of cycle in the peak period
         - ``band_amp`` : average analytic amplitude of the oscillation.
 
-        When consistency burst detection is used (i.e. burst_method = 'cycles'):
+        When consistency burst detection is used (i.e. burst_method='cycles'):
 
         - ``amp_fraction`` : normalized amplitude
         - ``amp_consistency`` : difference in the rise and decay voltage within a cycle
@@ -83,11 +84,11 @@ def compute_features(sig, fs, f_range, center_extrema='peak', burst_method='cycl
         - ``monotonicity`` : fraction of instantaneous voltage changes between consecutive
           samples that are positive during the rise phase and negative during the decay phase
 
-        When dual threshold burst detection is used (i.e. burst_method = 'amp'):
+        When dual threshold burst detection is used (i.e. burst_method='amp'):
 
         - ``burst_fraction`` : fraction of a cycle that is bursting
 
-        When cyclepoints are returned (i.e. deafault, return_samples = True)
+        When cyclepoints are returned (i.e. default, return_samples=True)
 
         - ``sample_peak`` : sample of 'sig' at which the peak occurs
         - ``sample_zerox_decay`` : sample of the decaying zero-crossing
@@ -146,8 +147,6 @@ def compute_features(sig, fs, f_range, center_extrema='peak', burst_method='cycl
         raise ValueError('Invalid argument for "burst_method".'
                          'Either "cycles" or "amp" must be specified."')
 
-    if return_samples is False:
-        sample_columns = [col for col in df_features.columns if col.startswith('sample_')]
-        df_features = df_features.drop(sample_columns, axis=1)
+    df_features = drop_samples_df(df_features) if return_samples is False else df_features
 
     return df_features

--- a/bycycle/features/shape.py
+++ b/bycycle/features/shape.py
@@ -6,14 +6,14 @@ import pandas as pd
 from neurodsp.timefrequency import amp_by_time
 
 from bycycle.utils.checks import check_param
-from bycycle.utils import rename_extrema_df
+from bycycle.utils import rename_extrema_df, check_param
 from bycycle.features.cyclepoints import compute_cyclepoints
 
 ###################################################################################################
 ###################################################################################################
 
-def compute_shape_features(sig, fs, f_range, center_extrema='peak', find_extrema_kwargs=None,
-                           n_cycles=3, return_samples=True):
+def compute_shape_features(sig, fs, f_range, center_extrema='peak',
+                           find_extrema_kwargs=None, n_cycles=3):
     """Compute shape features for each cycle.
 
     Parameters
@@ -36,8 +36,6 @@ def compute_shape_features(sig, fs, f_range, center_extrema='peak', find_extrema
         cycles of the low cutoff frequency (``f_range[0]``).
     n_cycles : int, optional, default: 3
         Length of filter, in number of cycles, at the lower cutoff frequency.
-    return_samples : bool, optional, default: True
-        Returns samples indices of cyclepoints used for determining features if True.
 
     Returns
     -------
@@ -57,11 +55,6 @@ def compute_shape_features(sig, fs, f_range, center_extrema='peak', find_extrema
         - ``time_rdsym`` : fraction of cycle in the rise period
         - ``time_ptsym`` : fraction of cycle in the peak period
         - ``band_amp`` : average analytic amplitude of the oscillation
-
-    df_samples : pandas.DataFrame, optional, default: True
-        Dataframe containing sample indices of cyclepoints.
-        Columns (listed for peak-centered cycles):
-
         - ``sample_peak`` : sample of 'sig' at which the peak occurs
         - ``sample_zerox_decay`` : sample of the decaying zero-crossing
         - ``sample_zerox_rise`` : sample of the rising zero-crossing
@@ -84,7 +77,7 @@ def compute_shape_features(sig, fs, f_range, center_extrema='peak', find_extrema
     >>> from neurodsp.sim import sim_bursty_oscillation
     >>> fs = 500
     >>> sig = sim_bursty_oscillation(10, fs, freq=10)
-    >>> df_shapes, df_samples = compute_shape_features(sig, fs, f_range=(8, 12))
+    >>> df_shapes = compute_shape_features(sig, fs, f_range=(8, 12))
     """
 
     # Ensure arguments are within valid ranges
@@ -140,11 +133,10 @@ def compute_shape_features(sig, fs, f_range, center_extrema='peak', find_extrema
     shape_features['band_amp'] = band_amp
     df_shape_features = pd.DataFrame.from_dict(shape_features)
 
-    # Rename the dataframe if trough centered
-    df_shape_features, df_samples = rename_extrema_df(center_extrema, df_samples, df_shape_features)
+    df_shape_features = pd.concat((df_shape_features, df_samples), axis=1)
 
-    if return_samples:
-        return df_shape_features, df_samples
+    # Rename the dataframe if trough centered
+    df_shape_features = rename_extrema_df(center_extrema, df_shape_features)
 
     return df_shape_features
 

--- a/bycycle/features/shape.py
+++ b/bycycle/features/shape.py
@@ -5,7 +5,6 @@ import pandas as pd
 
 from neurodsp.timefrequency import amp_by_time
 
-from bycycle.utils.checks import check_param
 from bycycle.utils import rename_extrema_df, check_param
 from bycycle.features.cyclepoints import compute_cyclepoints
 

--- a/bycycle/group/features.py
+++ b/bycycle/group/features.py
@@ -160,7 +160,7 @@ def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
                     dfs_features[idx] = detect_bursts_amp(dfs_features[idx], **thresholds)
 
     else:
-        raise ValueError("The axis kwarg must be either 1 or None.")
+        raise ValueError("The axis kwarg must be either 0 or None.")
 
     return dfs_features
 
@@ -278,7 +278,7 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
 
         df_2d = compute_features_2d(sigs_2d, fs, f_range, compute_features_kwargs=kwargs,
                                     return_samples=return_samples, n_jobs=n_jobs,
-                                    progress=progress, axis=1)
+                                    progress=progress, axis=0)
 
     else:
 

--- a/bycycle/group/features.py
+++ b/bycycle/group/features.py
@@ -194,7 +194,7 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
         Whether to return a dataframe of cyclepoint sample indices.
     n_jobs : int, optional, default: -1
         The number of jobs, one per cpu, to compute features in parallel.
-    progress : {None, 'tqdm', 'tqdm.notebook'}, optional, default: None
+    progress : {None, 'tqdm', 'tqdm.notebook'}
         Specify whether to display a progress bar. Use 'tqdm' if installed.
 
     Returns

--- a/bycycle/group/features.py
+++ b/bycycle/group/features.py
@@ -1,6 +1,7 @@
 """Functions to compute features across 2 dimensional arrays of data."""
 
 import warnings
+from copy import deepcopy
 from functools import partial
 from multiprocessing import Pool, cpu_count
 
@@ -91,7 +92,7 @@ def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
     """
 
     # Check compute_features_kwargs
-    kwargs = compute_features_kwargs
+    kwargs = deepcopy(compute_features_kwargs)
     kwargs = np.array(kwargs) if isinstance(kwargs, list) else kwargs
 
     check_kwargs_shape(sigs, kwargs, axis)
@@ -272,7 +273,7 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
     df_features = []
 
     # Convert list of kwargs to array to check dimensions
-    kwargs = compute_features_kwargs
+    kwargs = deepcopy(compute_features_kwargs)
     kwargs = np.array(kwargs) if isinstance(kwargs, list) else kwargs
 
     check_kwargs_shape(sigs, kwargs, axis)

--- a/bycycle/group/features.py
+++ b/bycycle/group/features.py
@@ -308,5 +308,5 @@ def _proxy_3d(args, fs=None, f_range=None, return_samples=None):
 
     sigs, kwargs = args[0], args[1]
 
-    return compute_features_2d(sigs, fs=fs, f_range=f_range, return_samples=return_samples,
-                               compute_features_kwargs=kwargs, axis=None)
+    return compute_features_2d(sigs, fs, f_range, compute_features_kwargs=kwargs, axis=None,
+                               return_samples=return_samples)

--- a/bycycle/group/features.py
+++ b/bycycle/group/features.py
@@ -103,17 +103,7 @@ def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None,
                                         **compute_features_kwargs[0]),
                                 sigs)
 
-        if return_samples is True:
-            df_features, df_samples = zip(*progress_bar(mapping, progress, len(sigs)))
-
-            df_features = list(df_features)
-            df_samples = list(df_samples)
-
-        else:
-            df_features = list(progress_bar(mapping, progress, len(sigs)))
-
-    if return_samples is True:
-        return df_features, df_samples
+        df_features = list(progress_bar(mapping, progress, len(sigs)))
 
     return df_features
 
@@ -231,16 +221,8 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None,
         compute_features_2d(sigs_2d, fs, f_range, compute_features_kwargs=kwargs,
                             return_samples=return_samples, n_jobs=n_jobs, progress=progress)
 
-    if return_samples:
-
-        df_features, df_samples = df_features[0], df_features[1]
-        df_samples = _reshape_df(df_samples, sigs)
-
     # Reshape returned features to match the first two dimensions of sigs
     df_features = _reshape_df(df_features, sigs)
-
-    if return_samples:
-        return df_features, df_samples
 
     return df_features
 

--- a/bycycle/group/features.py
+++ b/bycycle/group/features.py
@@ -32,10 +32,10 @@ def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
     axis : {0, None}
         Which axes to calculate features across:
 
-        - ``axis=0`` : Features are computed for each signal independently
-          across the first axis, i.e. for each channels in (n_channels, n_samples).
-        - ``axis=None`` : Features are computed across a flattened 1d array, i.e. across flatten
-          epochs in (n_epochs, n_samples).
+        - ``axis=1`` : Iterates over each row/signal in an array independently (i.e. for each
+          channel in (n_channels, n_timepoints)).
+        - ``axis=None`` : Flattens rows/signals prior to computing features (i.e. across flatten
+          epochs in (n_epochs, n_timepoints)).
 
     return_samples : bool, optional, default: True
         Whether to return a dataframe of cyclepoint sample indices.
@@ -182,13 +182,12 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
     axis : {0, 1, (0, 1)}
         Which axes to calculate features across:
 
-
-        - ``axis = 0`` : Features are computed for each signal independently
-          across the zeroth axis, i.e. across channels in (n_channels, n_epochs, n_samples).
-        - ``axis = 1`` : Features are computed for each signal independently
-          across the firt axis, i.e. across channels in (n_epochs, n_channels, n_samples).
-        - ``axis = (0, 1)`` : Features are computed independently for each signal. This is analogous to
-          ``axis = 1`` in :func:`~.compute_features_2d`.
+        - ``axis=0`` : Iterates over 2D slices along the zeroth dimension, (i.e. for each channel in
+          (n_channels, n_epochs, n_timepoints)).
+        - ``axis=1`` : Iterates over 2D slices along the first dimension (i.e. across flatten epochs
+          in (n_epochs, n_timepoints)).
+        - ``axis=(0, 1)`` : Iterates over 1D slices along the zeroth and first dimension (i.e across
+          each signal independently in (n_participants, n_channels, n_timepoints)).
 
     return_samples : bool, optional, default: True
         Whether to return a dataframe of cyclepoint sample indices.
@@ -213,8 +212,6 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
       dimensions of ``sigs`` may also be used to applied unique parameters to each signal.
     - ``return_samples`` is controlled from the kwargs passed in this function. The
       ``return_samples`` value in ``compute_features_kwargs`` will be ignored.
-    - When ``axis = None`` parallel computation may not be performed due to the
-      requirement of flattening the array into one dimension.
 
     Examples
     --------

--- a/bycycle/group/features.py
+++ b/bycycle/group/features.py
@@ -15,7 +15,7 @@ from bycycle.utils.dataframes import epoch_df
 ###################################################################################################
 ###################################################################################################
 
-def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None, axis=1,
+def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
                         return_samples=True, n_jobs=-1, progress=None):
     """Compute shape and burst features for a 2 dimensional array of signals.
 
@@ -32,7 +32,7 @@ def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None, axis=1,
     axis : {0, None}
         Which axes to calculate features across:
 
-        - ``axis=1`` : Features are computed for each signal independently
+        - ``axis=0`` : Features are computed for each signal independently
           across the first axis, i.e. for each channels in (n_channels, n_samples).
         - ``axis=None`` : Features are computed across a flattened 1d array, i.e. across flatten
           epochs in (n_epochs, n_samples).
@@ -71,7 +71,7 @@ def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None, axis=1,
     >>> fs = 500
     >>> sigs = np.array([sim_bursty_oscillation(10, fs, 10) for i in range(10)])
     >>> compute_kwargs = {'burst_method': 'amp', 'threshold_kwargs':{'burst_fraction_threshold': 1}}
-    >>> dfs_features = compute_features_2d(sigs, fs, f_range=(8, 12), axis=1,
+    >>> dfs_features = compute_features_2d(sigs, fs, f_range=(8, 12), axis=0,
     ...                                   compute_features_kwargs=compute_kwargs)
 
     Compute the features of a 2d array in parallel using the same compute_features kwargs. Note each
@@ -88,7 +88,7 @@ def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None, axis=1,
     >>> compute_kwargs = [{'threshold_kwargs': {'amp_consistency_threshold': thresh*.1}}
     ...                   for thresh in range(1, 11)]
     >>> dfs_features = compute_features_2d(sigs, fs, f_range=(8, 12), return_samples=False,
-    ...                                   n_jobs=2, compute_features_kwargs=compute_kwargs, axis=1)
+    ...                                   n_jobs=2, compute_features_kwargs=compute_kwargs, axis=0)
     """
 
     # Check compute_features_kwargs
@@ -106,7 +106,7 @@ def compute_features_2d(sigs, fs, f_range, compute_features_kwargs=None, axis=1,
 
     n_jobs = cpu_count() if n_jobs == -1 else n_jobs
 
-    if axis == 1:
+    if axis == 0:
         # Compute each signal independently and in paralllel
         with Pool(processes=n_jobs) as pool:
 

--- a/bycycle/group/features.py
+++ b/bycycle/group/features.py
@@ -179,7 +179,7 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
         Frequency range for narrowband signal of interest, in Hz.
     compute_features_kwargs : dict or 1d list of dict or 2d list of dict
         Keyword arguments used in :func:`~.compute_features`.
-    axis : {0, 1, 2}
+    axis : {0, 1, (0, 1)}
         Which axes to calculate features across:
 
 
@@ -187,7 +187,7 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
           across the zeroth axis, i.e. across channels in (n_channels, n_epochs, n_samples).
         - ``axis = 1`` : Features are computed for each signal independently
           across the firt axis, i.e. across channels in (n_epochs, n_channels, n_samples).
-        - ``axis = 2`` : Features are computed independently for each signal. This is analogous to
+        - ``axis = (0, 1)`` : Features are computed independently for each signal. This is analogous to
           ``axis = 1`` in :func:`~.compute_features_2d`.
 
     return_samples : bool, optional, default: True
@@ -271,7 +271,7 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
         # Swap the first two axes to return original shape
         dfs_features = [list(dfs) for dfs in zip(*dfs_features)] if axis == 1 else dfs_features
 
-    elif axis == 2:
+    elif axis == (0, 1):
         # Independently across the first two axes (i.e. for each signal)
         sigs_2d = sigs.reshape(np.shape(sigs)[0]*np.shape(sigs)[1], np.shape(sigs)[2])
         kwargs = kwargs[0] if len(kwargs) == 1 else kwargs
@@ -282,9 +282,9 @@ def compute_features_3d(sigs, fs, f_range, compute_features_kwargs=None, axis=0,
 
     else:
 
-        raise ValueError("The axis kwarg must be either 0, 1, or 2.")
+        raise ValueError("The axis kwarg must be either 0, 1, or (0, 1).")
 
-    if axis == 2:
+    if axis == (0, 1):
 
         dfs_features = np.zeros((np.shape(sigs)[0], np.shape(sigs)[1])).tolist()
 

--- a/bycycle/group/utils.py
+++ b/bycycle/group/utils.py
@@ -89,8 +89,8 @@ def check_kwargs_shape(sigs, compute_features_kwargs, axis):
 
     Parameters
     ----------
-    sigs : 3d array
-        Voltage time series, with 3d shape, i.e. (n_channels, n_epochs, n_samples).
+    sigs : 2d or 3d array
+        Voltage time series.
     compute_features_kwargs : dict or 1d list of dict or 2d list of dict
         Keyword arguments used in :func:`~.compute_features`.
     axis : int or tuple or None, {0, 1, (0, 1), None}
@@ -141,6 +141,9 @@ def check_kwargs_shape(sigs, compute_features_kwargs, axis):
     elif axis == None and kwargs.ndim == 2 and \
         (kwargs_dim0 != sigs_dim0 or kwargs_dim1 != sigs_dim1):
         axis_str = 'first and second'
+
+    elif axis == (0, 1) and kwargs.ndim == 1 and sigs.ndim == 2:
+        raise ValueError("When axis = (0, 1), a 3-dimensional signal is required.")
 
     else:
         return

--- a/bycycle/group/utils.py
+++ b/bycycle/group/utils.py
@@ -93,7 +93,7 @@ def check_kwargs_shape(sigs, compute_features_kwargs, axis):
         Voltage time series.
     compute_features_kwargs : dict or 1d list of dict or 2d list of dict
         Keyword arguments used in :func:`~.compute_features`.
-    axis : {None, 0, 1, 2}
+    axis : {None, 0, 1, (0, 1)}
         Which axes to calculate features across.
 
     Raises
@@ -119,23 +119,23 @@ def check_kwargs_shape(sigs, compute_features_kwargs, axis):
     sigs_dim1 = np.shape(sigs)[1] if sigs.ndim == 3 else None
 
     # 2D checks
-    if sigs_dim1 == None and (axis==0 or axis==None) and kwargs_dim0 != sigs_dim0:
+    if sigs_dim1 == None and axis in [0, None] and kwargs_dim0 != sigs_dim0:
         kwargs_shape = (sigs_dim0,)
-    elif sigs_dim1 == None and (axis==0 or axis==None) and kwargs_dim1 is not None:
+    elif sigs_dim1 == None and axis in [0, None] and kwargs_dim1 is not None:
         kwargs_shape = (sigs_dim0,)
 
     # 3D checks
-    elif sigs_dim1 != None and axis==0 and kwargs_dim0 != sigs_dim0:
+    elif sigs_dim1 != None and axis == 0 and kwargs_dim0 != sigs_dim0:
         kwargs_shape = (sigs_dim0,)
-    elif sigs_dim1 != None and axis==1 and kwargs_dim0 != sigs_dim1:
+    elif sigs_dim1 != None and axis == 1 and kwargs_dim0 != sigs_dim1:
         kwargs_shape = (sigs_dim1,)
-    elif sigs_dim1 != None and axis==(0,1) and (kwargs_dim0!=sigs_dim0 or kwargs_dim1!=sigs_dim1):
+    elif sigs_dim1 != None and axis == (0,1) and (kwargs_dim0!=sigs_dim0 or kwargs_dim1!=sigs_dim1):
         kwargs_shape = (sigs_dim0, sigs_dim1)
 
     # Axis checks
-    elif sigs_dim1 == None and (axis != 0 and axis != None):
+    elif sigs_dim1 == None and axis not in [0, None]:
         raise ValueError("When sigs is 2D, axis must be either {0, None}.")
-    elif sigs_dim1 != None and (axis != 0 and axis != 1 and axis != (0, 1)):
+    elif sigs_dim1 != None and axis not in [0, 1, (0, 1)]:
         raise ValueError("When sigs is 3D, axis must be either {0, 1, (0, 1)}")
     else:
         return

--- a/bycycle/plts/burst.py
+++ b/bycycle/plts/burst.py
@@ -70,7 +70,7 @@ def plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, xlim=None,
     >>> sig = sim_bursty_oscillation(10, fs, freq=10)
     >>> threshold_kwargs = {'amp_fraction_threshold': 0., 'amp_consistency_threshold': .5,
     ...                     'period_consistency_threshold': .5, 'monotonicity_threshold': .8}
-    >>> df_features= compute_features(sig, fs, f_range=(8, 12), threshold_kwargs=threshold_kwargs)
+    >>> df_features = compute_features(sig, fs, f_range=(8, 12), threshold_kwargs=threshold_kwargs)
     >>> plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs)
     """
 

--- a/bycycle/plts/burst.py
+++ b/bycycle/plts/burst.py
@@ -3,7 +3,6 @@
 from itertools import cycle
 
 import numpy as np
-import pandas as pd
 from scipy.stats import zscore
 import matplotlib.pyplot as plt
 
@@ -131,7 +130,7 @@ def plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, xlim=None,
         color = next(colors)
 
         # Highlight where a burst param falls below threshold
-        for row_idx, cyc in df_features.iterrows():
+        for _, cyc in df_features.iterrows():
 
             if cyc[column] < threshold_kwargs[osc_key]:
                 axes[0].axvspan(times[int(cyc['sample_last_' + side_e])],

--- a/bycycle/tests/burst/test_amp.py
+++ b/bycycle/tests/burst/test_amp.py
@@ -13,12 +13,10 @@ from bycycle.burst.amp import *
 def test_detect_bursts_amp(sim_args):
 
     df_shape_features = sim_args['df_shapes']
-    df_samples = sim_args['df_samples']
     sig = sim_args['sig']
     burst_kwarg = {'fs': sim_args['fs'], 'f_range': sim_args['f_range'], 'amp_threshes': (0.5, 1)}
 
-    df_features = compute_burst_features(df_shape_features, df_samples, sig,
-                                         burst_method='amp',
+    df_features = compute_burst_features(df_shape_features, sig, burst_method='amp',
                                          burst_kwargs=burst_kwarg)
 
     # Apply dual threshold burst detection

--- a/bycycle/tests/burst/test_utils.py
+++ b/bycycle/tests/burst/test_utils.py
@@ -44,8 +44,7 @@ def test_recompute_edges(sim_args_comb):
     sig_force_recomp[:int(fs *  n_seconds)] = sig
     sig_force_recomp[int(fs * n_seconds) + fs:] = sig
 
-    df_features = compute_features(sig, fs, f_range, threshold_kwargs=threshold_kwargs,
-                                   return_samples=False)
+    df_features = compute_features(sig, fs, f_range, threshold_kwargs=threshold_kwargs)
 
     # Update thresholds to give all edge cycles is_burst = True, except for the first and
     #   last cycles, since these cycles contain np.nan values for consistency measures

--- a/bycycle/tests/conftest.py
+++ b/bycycle/tests/conftest.py
@@ -79,4 +79,3 @@ def sim_stationary():
     sig = sim_oscillation(N_SECONDS, FS, FREQ, phase=0.15,
                           cycle="asine", rdsym=.3)
     yield sig
-

--- a/bycycle/tests/conftest.py
+++ b/bycycle/tests/conftest.py
@@ -25,9 +25,9 @@ def sim_args():
 
     sig = sim_oscillation(N_SECONDS, FS, FREQ)
 
-    df_shapes, df_samples = compute_shape_features(sig, FS, F_RANGE, return_samples=True)
-    df_burst = compute_burst_features(df_shapes, df_samples, sig)
-    df_features, df_samples = compute_features(sig, FS, F_RANGE, return_samples=True)
+    df_shapes = compute_shape_features(sig, FS, F_RANGE)
+    df_burst = compute_burst_features(df_shapes, sig)
+    df_features = compute_features(sig, FS, F_RANGE)
 
     threshold_kwargs = {'amp_fraction_threshold': 0.,
                         'amp_consistency_threshold': .5,
@@ -36,8 +36,7 @@ def sim_args():
                         'min_n_cycles': 3}
 
     yield {'sig': sig, 'fs': FS, 'f_range': F_RANGE, 'df_features': df_features,
-           'df_shapes': df_shapes, 'df_burst': df_burst, 'df_samples': df_samples,
-           'threshold_kwargs': threshold_kwargs}
+           'df_shapes': df_shapes, 'df_burst': df_burst, 'threshold_kwargs': threshold_kwargs}
 
 
 @pytest.fixture(scope='module')
@@ -47,9 +46,9 @@ def sim_args_comb():
 
     sig = sim_combined(N_SECONDS, FS, components=components)
 
-    df_shapes, df_samples = compute_shape_features(sig, FS, F_RANGE, return_samples=True)
-    df_burst = compute_burst_features(df_shapes, df_samples, sig)
-    df_features, df_samples = compute_features(sig, FS, F_RANGE, return_samples=True)
+    df_shapes = compute_shape_features(sig, FS, F_RANGE)
+    df_burst = compute_burst_features(df_shapes, sig)
+    df_features = compute_features(sig, FS, F_RANGE)
 
     threshold_kwargs = {'amp_fraction_threshold': 0.,
                         'amp_consistency_threshold': .5,
@@ -58,8 +57,7 @@ def sim_args_comb():
                         'min_n_cycles': 3}
 
     yield {'sig': sig, 'fs': FS, 'f_range': F_RANGE, 'df_features': df_features,
-           'df_shapes': df_shapes, 'df_burst': df_burst, 'df_samples': df_samples,
-           'threshold_kwargs': threshold_kwargs}
+           'df_shapes': df_shapes, 'df_burst': df_burst, 'threshold_kwargs': threshold_kwargs}
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/bycycle/tests/cyclepoints/test_extrema.py
+++ b/bycycle/tests/cyclepoints/test_extrema.py
@@ -1,7 +1,5 @@
 """Tests for cyclepoints.extrema."""
 
-import os
-
 import numpy as np
 from scipy.signal import argrelextrema
 
@@ -51,7 +49,3 @@ def test_find_extrema(sim_args, first_extrema):
         assert len(peaks) == len(troughs)
         np.testing.assert_equal(peaks, maxima[0])
         np.testing.assert_equal(troughs, minima[0])
-
-
-
-

--- a/bycycle/tests/cyclepoints/test_phase.py
+++ b/bycycle/tests/cyclepoints/test_phase.py
@@ -1,11 +1,8 @@
 """Tests for cyclepoints.phase."""
 
-import os
-
 import numpy as np
 
 from bycycle.cyclepoints import find_extrema, find_zerox
-
 from bycycle.cyclepoints.phase import *
 
 ###################################################################################################

--- a/bycycle/tests/cyclepoints/test_zerox.py
+++ b/bycycle/tests/cyclepoints/test_zerox.py
@@ -1,9 +1,5 @@
 """Tests for cyclepoints.zerox."""
 
-import os
-
-import numpy as np
-
 from bycycle.cyclepoints import find_extrema
 
 from bycycle.cyclepoints.zerox import *

--- a/bycycle/tests/features/test_burst.py
+++ b/bycycle/tests/features/test_burst.py
@@ -15,7 +15,6 @@ def test_compute_burst_features(sim_args, dual_thresh, center_e):
 
     sig = sim_args['sig']
     df_shape_features = sim_args['df_shapes']
-    df_samples = sim_args['df_samples']
 
     if center_e == 'trough':
 
@@ -26,15 +25,14 @@ def test_compute_burst_features(sim_args, dual_thresh, center_e):
                        'sample_last_trough': 'sample_last_peak',
                        'sample_next_trough': 'sample_next_peak'}
 
-        df_samples.rename(columns=rename_dict, inplace=True)
+        df_shape_features.rename(columns=rename_dict, inplace=True)
 
     if dual_thresh:
 
         # Use dual threshold burst detecion.
         burst_detection_kwargs =  {'fs': sim_args['fs'], 'f_range': sim_args['f_range']}
 
-        df_burst_features = compute_burst_features(df_shape_features, df_samples, sig,
-                                                   burst_method='amp',
+        df_burst_features = compute_burst_features(df_shape_features, sig, burst_method='amp',
                                                    burst_kwargs=burst_detection_kwargs)
 
         burst_fraction = df_burst_features['burst_fraction']
@@ -46,7 +44,7 @@ def test_compute_burst_features(sim_args, dual_thresh, center_e):
     else:
 
         # Use consistency burst detection
-        df_burst_features = compute_burst_features(df_shape_features, df_samples, sig)
+        df_burst_features = compute_burst_features(df_shape_features, sig)
 
         amp_fraction = df_burst_features['amp_fraction'].values[1:-1]
         amp_consistency = df_burst_features['amp_consistency'].values[1:-1]

--- a/bycycle/tests/features/test_features.py
+++ b/bycycle/tests/features/test_features.py
@@ -38,16 +38,10 @@ def test_compute_features(sim_args, return_samples, burst_method):
 
     if return_samples:
 
-        df_features, df_samples = df_features[0], df_features[1]
-        assert len(df_features) == len(df_samples)
+        sample_cols = [col for col in list(df_features.columns) if "sample_" in col]
+        assert len(sample_cols) == 6
 
     # Assert that np.nan isn't in dataframe columns
     for _, column in df_features.iteritems():
 
         assert not np.isnan(column[1:-1]).any()
-
-    if return_samples:
-
-        for _, row in df_samples.iterrows():
-
-            assert not np.isnan(row).any()

--- a/bycycle/tests/features/test_shapes.py
+++ b/bycycle/tests/features/test_shapes.py
@@ -24,41 +24,31 @@ from bycycle.features.shape import *
         pytest.param(None, marks=pytest.mark.xfail)
     ]
 )
-@pytest.mark.parametrize("return_samples", [True, False])
-def test_compute_shape_features(sim_args, find_extrema_kwargs, center_extrema, return_samples):
+def test_compute_shape_features(sim_args, find_extrema_kwargs, center_extrema):
 
     sig = sim_args['sig']
     fs = sim_args['fs']
     f_range = sim_args['f_range']
 
-    outs = compute_shape_features(sig, fs, f_range,
-                                  center_extrema=center_extrema,
-                                  find_extrema_kwargs=find_extrema_kwargs,
-                                  return_samples=return_samples)
+    df_shapes = compute_shape_features(sig, fs, f_range, center_extrema=center_extrema,
+                                       find_extrema_kwargs=find_extrema_kwargs)
 
-    if return_samples:
-        df_shapes, df_samples = outs
-        assert len(df_shapes) == len(df_samples)
-
-    else:
-        df_shapes = outs
+    # Ensure sample columns are returned
+    sample_cols = [col for col in list(df_shapes.columns) if "sample_" in col]
+    assert len(sample_cols) == 6
 
     # Assert that np.nan isn't dataframe(s), with the exception of the first and last row
     for idx, row in df_shapes.iterrows():
 
         assert not np.isnan(row[1:-1]).any()
 
-        if return_samples:
-
-            assert not np.isnan(df_samples.iloc[idx]).any()
 
     # Check inverted signal gives appropriately opposite data
     extrema_opp = 'trough' if center_extrema == 'peak' else 'peak'
 
     df_opp = compute_shape_features(-sig, fs, f_range,
                                     center_extrema=extrema_opp,
-                                    find_extrema_kwargs=find_extrema_kwargs,
-                                    return_samples=False)
+                                    find_extrema_kwargs=find_extrema_kwargs)
 
     cols_peak = ['time_peak', 'time_rise', 'volt_rise',
                  'volt_amp', 'period', 'time_rdsym', 'time_ptsym']
@@ -78,18 +68,18 @@ def test_compute_shape_features(sim_args, find_extrema_kwargs, center_extrema, r
 
 def test_compute_durations(sim_args):
 
-    df_samples = sim_args['df_samples']
-    period, time_peak, time_trough = compute_durations(df_samples)
+    df_shapes = sim_args['df_shapes']
+    period, time_peak, time_trough = compute_durations(df_shapes)
 
     assert ((time_trough + time_peak) == period).all()
 
 
 def test_compute_extrema_voltage(sim_args):
 
-    df_samples = sim_args['df_samples']
+    df_shapes = sim_args['df_shapes']
     sig = sim_args['sig']
 
-    volt_peaks, volt_troughs = compute_extrema_voltage(df_samples, sig)
+    volt_peaks, volt_troughs = compute_extrema_voltage(df_shapes, sig)
 
     for idx, volt_peak in enumerate(volt_peaks):
         assert volt_peak > volt_troughs[idx]
@@ -98,14 +88,14 @@ def test_compute_extrema_voltage(sim_args):
 @pytest.mark.parametrize("recompute", [True, False])
 def test_compute_symmetry(sim_args, recompute):
 
-    df_samples = sim_args['df_samples']
+    df_shapes = sim_args['df_shapes']
     sig = sim_args['sig']
 
     if recompute:
-        sym_features = compute_symmetry(df_samples, sig)
+        sym_features = compute_symmetry(df_shapes, sig)
     else:
-        period, time_peak, time_trough = compute_durations(df_samples)
-        sym_features = compute_symmetry(df_samples, sig, period=period,
+        period, time_peak, time_trough = compute_durations(df_shapes)
+        sym_features = compute_symmetry(df_shapes, sig, period=period,
                                         time_peak=time_peak, time_trough=time_trough)
 
     # This is the case for only simulated sine waves
@@ -121,12 +111,12 @@ def test_compute_symmetry(sim_args, recompute):
 
 def test_compute_band_amp(sim_args):
 
-    df_samples = sim_args['df_samples']
+    df_shapes = sim_args['df_shapes']
     sig = sim_args['sig']
     fs = sim_args['fs']
     f_range = sim_args['f_range']
 
-    band_amp = compute_band_amp(df_samples, sig, fs, f_range)
+    band_amp = compute_band_amp(df_shapes, sig, fs, f_range)
 
     for amp in band_amp[:-1]:
         np.testing.assert_allclose(amp, band_amp[0], rtol=1e-1)

--- a/bycycle/tests/features/test_shapes.py
+++ b/bycycle/tests/features/test_shapes.py
@@ -4,8 +4,6 @@ import pytest
 
 import numpy as np
 
-from bycycle.cyclepoints import find_extrema, find_zerox
-
 from bycycle.features.shape import *
 
 ###################################################################################################

--- a/bycycle/tests/group/test_features.py
+++ b/bycycle/tests/group/test_features.py
@@ -69,7 +69,7 @@ def test_compute_features_2d(sim_args, kwargs_dtype, axis):
 
 
 @mark.parametrize("return_samples", [True, False])
-@mark.parametrize("axis", [0, 1, 2, param(3, marks=mark.xfail)])
+@mark.parametrize("axis", [0, 1, (0, 1), param(3, marks=mark.xfail)])
 def test_compute_features_3d(sim_args, return_samples, axis):
 
     dim1 = 3

--- a/bycycle/tests/group/test_features.py
+++ b/bycycle/tests/group/test_features.py
@@ -12,7 +12,7 @@ from bycycle.group.features import compute_features_2d, compute_features_3d
 ###################################################################################################
 
 @mark.parametrize("kwargs_dtype", ['dict', 'list_cycles', 'list_amp', None])
-@mark.parametrize("axis", [0, None, param(1, marks=mark.xfail)])
+@mark.parametrize("axis", [None, 1, param(2, marks=mark.xfail)])
 def test_compute_features_2d(sim_args, kwargs_dtype, axis):
 
     n_sigs = 5
@@ -46,7 +46,7 @@ def test_compute_features_2d(sim_args, kwargs_dtype, axis):
                                        axis=axis)
 
     # Parallel processing (assuming >1 job is available)
-    if axis == 0:
+    if axis == 1:
 
         features_par = compute_features_2d(sigs, fs, f_range, n_jobs=-1, return_samples=True,
                                            compute_features_kwargs=compute_features_kwargs)
@@ -67,15 +67,9 @@ def test_compute_features_2d(sim_args, kwargs_dtype, axis):
         assert not features_seq[0].equals(features_seq[1])
         assert not features_seq[-1].equals(features_seq[1])
 
-    else:
-
-        # All dfs will be equal when computed independently
-        for df_seq in features_seq[1:]:
-            features_seq[0].equals(df_seq)
-
 
 @mark.parametrize("return_samples", [True, False])
-@mark.parametrize("axis", [0, 1, (0, 1), None, param(2, marks=mark.xfail)])
+@mark.parametrize("axis", [0, 1, 2, param(3, marks=mark.xfail)])
 def test_compute_features_3d(sim_args, return_samples, axis):
 
     dim1 = 3
@@ -114,8 +108,3 @@ def test_compute_features_3d(sim_args, return_samples, axis):
             for col_idx in range(dim2):
                 if row_idx != 0 and col_idx != 0:
                     assert df_features[0][0].equals(df_features[row_idx][col_idx])
-
-    elif axis == None:
-        # Dataframes will be equal, except the first and last dfs (edge artifacts)
-        for row_idx, col_idx in list(product(range(0, dim1), range(0, dim2)))[2:-1]:
-            pd.testing.assert_frame_equal(df_features[row_idx][col_idx], df_features[0][1])

--- a/bycycle/tests/group/test_features.py
+++ b/bycycle/tests/group/test_features.py
@@ -4,15 +4,14 @@ from itertools import product
 import numpy as np
 import pandas as pd
 
-from pytest import mark, param
-
+import pytest
 from bycycle.group.features import compute_features_2d, compute_features_3d
 
 ###################################################################################################
 ###################################################################################################
 
-@mark.parametrize("kwargs_dtype", ['dict', 'list_cycles', 'list_amp', None])
-@mark.parametrize("axis", [None, 0, param(2, marks=mark.xfail)])
+@pytest.mark.parametrize("kwargs_dtype", ['dict', 'list_cycles', 'list_amp', None])
+@pytest.mark.parametrize("axis", [None, 0, pytest.param(2, marks=pytest.mark.xfail)])
 def test_compute_features_2d(sim_args, kwargs_dtype, axis):
 
     n_sigs = 5
@@ -68,8 +67,8 @@ def test_compute_features_2d(sim_args, kwargs_dtype, axis):
         assert not features_seq[-1].equals(features_seq[1])
 
 
-@mark.parametrize("return_samples", [True, False])
-@mark.parametrize("axis", [0, 1, (0, 1), param(3, marks=mark.xfail)])
+@pytest.mark.parametrize("return_samples", [True, False])
+@pytest.mark.parametrize("axis", [0, 1, (0, 1), pytest.param(3, marks=pytest.mark.xfail)])
 def test_compute_features_3d(sim_args, return_samples, axis):
 
     dim1 = 3

--- a/bycycle/tests/group/test_features.py
+++ b/bycycle/tests/group/test_features.py
@@ -93,11 +93,29 @@ def test_compute_features_3d(sim_args, return_samples, axis):
         compute_features_3d(sigs_3d, fs, f_range, compute_features_kwargs=compute_features_kwargs,
                             return_samples=return_samples, n_jobs=-1, progress=None, axis=axis)
 
-    # Check lengths
     assert len(df_features) == dim1
     assert len(df_features[0]) == dim2
 
-    # Check equal values, skipping the first and last dfs
-    for row_idx, col_idx in list(product(range(0, dim1), range(0, dim2)))[2:-1]:
-        pd.testing.assert_frame_equal(df_features[row_idx][col_idx], df_features[0][1])
+    if axis == 0:
+        # Dataframes will be equal across the first axis
+        for row_idx in range(0, dim1):
+            for col_idx in range(dim2):
+                assert df_features[0][col_idx].equals(df_features[row_idx][col_idx])
 
+    elif axis == 1:
+        # Dataframes will be equal across the second axis
+        for row_idx in range(dim1):
+            for col_idx in range(1, dim2):
+                assert df_features[row_idx][0].equals(df_features[row_idx][col_idx])
+
+    elif axis == (0, 1):
+        # Dataframes will all be equal
+        for row_idx in range(dim1):
+            for col_idx in range(dim2):
+                if row_idx != 0 and col_idx != 0:
+                    assert df_features[0][0].equals(df_features[row_idx][col_idx])
+
+    elif axis == None:
+        # Dataframes will be equal, except the first and last dfs (edge artifacts)
+        for row_idx, col_idx in list(product(range(0, dim1), range(0, dim2)))[2:-1]:
+            pd.testing.assert_frame_equal(df_features[row_idx][col_idx], df_features[0][1])

--- a/bycycle/tests/group/test_features.py
+++ b/bycycle/tests/group/test_features.py
@@ -38,30 +38,22 @@ def test_compute_features_2d(sim_args, compute_features_kwargs_dtype,
         assert df_features.equals(features[0])
 
     # Sequential processing check
-    features_seq, samples_seq = \
-        compute_features_2d(sigs, fs, f_range, n_jobs=1, return_samples=True,
-                            compute_features_kwargs=compute_features_kwargs)
+    features_seq =  compute_features_2d(sigs, fs, f_range, n_jobs=1, return_samples=True,
+                                        compute_features_kwargs=compute_features_kwargs)
 
     # Parallel processing check
-    features, samples = compute_features_2d(sigs, fs, f_range, n_jobs=-1, return_samples=True,
-                                            compute_features_kwargs=compute_features_kwargs)
+    features = compute_features_2d(sigs, fs, f_range, n_jobs=-1, return_samples=True,
+                                   compute_features_kwargs=compute_features_kwargs)
 
     # Since the same signal is used, check that each df is the same
     for df_features in features_seq[1:]:
         assert df_features.equals(features_seq[0])
     for df_features in features[1:]:
         assert df_features.equals(features[0])
-    for df_samples in samples_seq[1:]:
-        assert df_samples.equals(samples_seq[0])
-    for df_samples in samples[1:]:
-        assert df_samples.equals(samples[0])
 
     # Assert that sequential and parallel processing is equivalent
     for idx, df_features in enumerate(features):
         assert df_features.equals(features_seq[idx])
-
-    for idx, df_samples in enumerate(samples):
-        assert df_samples.equals(samples_seq[idx])
 
 
 @mark.parametrize("compute_features_kwargs_error", [False, param(True, marks=mark.xfail)])
@@ -114,15 +106,8 @@ def test_compute_features_3d(sim_args, compute_features_kwargs_error,
                             return_samples=return_samples, n_jobs=-1, progress=None)
 
     # Check lengths
-    if return_samples:
-        df_features, df_samples = df_features[0], df_features[1]
-
-        assert len(df_features) == len(df_samples) == dim1
-        assert len(df_features[0])== len(df_samples[0]) == dim2
-
-    else:
-        assert len(df_features) == dim1
-        assert len(df_features[0]) == dim2
+    assert len(df_features) == dim1
+    assert len(df_features[0]) == dim2
 
     # Check equal values
     for row_idx in range(dim1):
@@ -130,5 +115,3 @@ def test_compute_features_3d(sim_args, compute_features_kwargs_error,
 
             assert df_features[row_idx][col_idx].equals(df_features[0][0])
 
-            if return_samples:
-                assert df_samples[row_idx][col_idx].equals(df_samples[0][0])

--- a/bycycle/tests/group/test_features.py
+++ b/bycycle/tests/group/test_features.py
@@ -12,7 +12,7 @@ from bycycle.group.features import compute_features_2d, compute_features_3d
 ###################################################################################################
 
 @mark.parametrize("kwargs_dtype", ['dict', 'list_cycles', 'list_amp', None])
-@mark.parametrize("axis", [None, 1, param(2, marks=mark.xfail)])
+@mark.parametrize("axis", [None, 0, param(2, marks=mark.xfail)])
 def test_compute_features_2d(sim_args, kwargs_dtype, axis):
 
     n_sigs = 5
@@ -46,7 +46,7 @@ def test_compute_features_2d(sim_args, kwargs_dtype, axis):
                                        axis=axis)
 
     # Parallel processing (assuming >1 job is available)
-    if axis == 1:
+    if axis == 0:
 
         features_par = compute_features_2d(sigs, fs, f_range, n_jobs=-1, return_samples=True,
                                            compute_features_kwargs=compute_features_kwargs)

--- a/bycycle/tests/group/test_features.py
+++ b/bycycle/tests/group/test_features.py
@@ -1,5 +1,6 @@
 """Test functions to compute features across epoched data."""
 
+from itertools import product
 import numpy as np
 import pandas as pd
 
@@ -10,45 +11,31 @@ from bycycle.group.features import compute_features_2d, compute_features_3d
 ###################################################################################################
 ###################################################################################################
 
-@mark.parametrize("compute_features_kwargs_error", [False, param(True, marks=mark.xfail)])
 @mark.parametrize("compute_features_kwargs_dtype", ['dict', 'list', None])
-@mark.parametrize("global_features", [True, False])
-def test_compute_features_2d(sim_args, compute_features_kwargs_dtype,
-                             compute_features_kwargs_error, global_features):
+@mark.parametrize("axis", [0, None, param(1, marks=mark.xfail)])
+def test_compute_features_2d(sim_args, compute_features_kwargs_dtype, axis):
 
     n_sigs = 5
     sigs = np.array([sim_args['sig']] * n_sigs)
     fs  = sim_args['fs']
     f_range = sim_args['f_range']
 
-    # return_samples is disregarded when used in compute_features_kwargs
+    # Note: return_samples is disregarded when used in compute_features_kwargs
     #   this variable is set directly in the function
     compute_features_kwargs = {'center_extrema': 'peak', 'return_samples': False}
 
-    if compute_features_kwargs_dtype == 'list' and compute_features_kwargs_error is False:
+    if compute_features_kwargs_dtype == 'list':
         compute_features_kwargs = [compute_features_kwargs] * n_sigs
-    elif compute_features_kwargs_dtype == 'list' and compute_features_kwargs_error is True:
-        compute_features_kwargs = [compute_features_kwargs] * 2
+
+        # Raise center extrema mistmatch warning
+        compute_features_kwargs[1] =  {'center_extrema': 'trough', 'return_samples': False}
+
     elif compute_features_kwargs_dtype == None:
          compute_features_kwargs = None
 
     # Sequential processing check
-    features_seq = compute_features_2d(sigs, fs, f_range, n_jobs=1, return_samples=True,
-                                       compute_features_kwargs=compute_features_kwargs,
-                                       global_features=global_features)
 
-    # Parallel processing check
-    if global_features is False:
-
-        features = compute_features_2d(sigs, fs, f_range, n_jobs=-1, return_samples=True,
-                                    compute_features_kwargs=compute_features_kwargs)
-
-
-        # Assert that sequential and parallel processing is equivalent
-        for idx, df_features in enumerate(features):
-            assert df_features.equals(features_seq[idx])
-
-    elif global_features is True:
+    def _none_check(features_seq):
 
         # When using global features, edge artifacts will exist in the first/last df
         for df_features in features_seq[2:-1]:
@@ -63,11 +50,44 @@ def test_compute_features_2d(sim_args, compute_features_kwargs_dtype,
         assert not features_seq[-1].equals(features_seq[1])
 
 
-@mark.parametrize("compute_features_kwargs_error", [False, param(True, marks=mark.xfail)])
-@mark.parametrize("compute_features_kwargs_dtype", ['dict', '1dlist', '2dlist', None])
+    if axis == None and compute_features_kwargs_dtype == 'list':
+
+        for burst_method in ['cycles', 'amp']:
+
+            compute_features_kwargs = [dict(kwargs, burst_method=burst_method) for kwargs in \
+                compute_features_kwargs]
+
+            features_seq = compute_features_2d(sigs, fs, f_range, n_jobs=1, return_samples=True,
+                                               compute_features_kwargs=compute_features_kwargs,
+                                               axis=axis)
+
+            _none_check(features_seq)
+
+    else:
+
+        features_seq = compute_features_2d(sigs, fs, f_range, n_jobs=1, return_samples=True,
+                                           compute_features_kwargs=compute_features_kwargs,
+                                           axis=axis)
+
+    # Parallel processing check
+    if axis == 0:
+
+        features = compute_features_2d(sigs, fs, f_range, n_jobs=-1, return_samples=True,
+                                       compute_features_kwargs=compute_features_kwargs)
+
+
+        # Assert that sequential and parallel processing is equivalent
+        for idx, df_features in enumerate(features):
+            assert df_features.equals(features_seq[idx])
+
+    elif axis is None and  compute_features_kwargs_dtype != 'list':
+
+        _none_check(features_seq)
+
+
 @mark.parametrize("return_samples", [True, False])
-def test_compute_features_3d(sim_args, compute_features_kwargs_error,
-                             compute_features_kwargs_dtype, return_samples):
+@mark.parametrize("axis", [0, 1, (0, 1), None, param(2, marks=mark.xfail)])
+def test_compute_features_3d(sim_args, return_samples, axis):
 
     dim1 = 3
     dim2 = 2
@@ -80,45 +100,15 @@ def test_compute_features_3d(sim_args, compute_features_kwargs_error,
 
     compute_features_kwargs = {'center_extrema': 'peak'}
 
-    # 1d list of kwargs dicts
-    if compute_features_kwargs_dtype == '1dlist':
-
-        if compute_features_kwargs_error is True:
-            # Mismatch dimension, error expected
-            compute_features_kwargs = [compute_features_kwargs] * (dim1 - 1)
-        else:
-            # Valid kwargs
-            compute_features_kwargs = [compute_features_kwargs] * dim1
-
-    # 2d list of kwargs dicts
-    elif compute_features_kwargs_dtype == '2dlist':
-
-        if compute_features_kwargs_error is True:
-            # Mismatch dimension, error expected
-            compute_features_kwargs = [compute_features_kwargs] * (dim2 - 1)
-        else:
-            # Valid kwargs
-            compute_features_kwargs = [compute_features_kwargs] * dim2
-
-        # Add 2d
-        compute_features_kwargs = [compute_features_kwargs] * dim1
-
-    # No kwargs passed
-    elif compute_features_kwargs_dtype == None:
-        compute_features_kwargs = None
-
-
     df_features = \
         compute_features_3d(sigs_3d, fs, f_range, compute_features_kwargs=compute_features_kwargs,
-                            return_samples=return_samples, n_jobs=-1, progress=None)
+                            return_samples=return_samples, n_jobs=-1, progress=None, axis=axis)
 
     # Check lengths
     assert len(df_features) == dim1
     assert len(df_features[0]) == dim2
 
-    # Check equal values
-    for row_idx in range(dim1):
-        for col_idx in range(dim2):
-
-            assert df_features[row_idx][col_idx].equals(df_features[0][0])
+    # Check equal values, skipping the first and last dfs
+    for row_idx, col_idx in list(product(range(0, dim1), range(0, dim2)))[2:-1]:
+        pd.testing.assert_frame_equal(df_features[row_idx][col_idx], df_features[0][1])
 

--- a/bycycle/tests/group/test_utils.py
+++ b/bycycle/tests/group/test_utils.py
@@ -20,11 +20,10 @@ def test_progress_bar(progress):
     assert len(pbar) == n_iterations
 
 
-@pytest.mark.parametrize("axis", [0, 1, 2, None, pytest.param(2, marks=pytest.mark.xfail)])
-@pytest.mark.parametrize("kwargs_ndim", [1, 2])
+@pytest.mark.parametrize("axis", [0, 1, (0, 1), None, pytest.param(2, marks=pytest.mark.xfail)])
 @pytest.mark.parametrize("sigs_ndim", [2, 3])
 @pytest.mark.parametrize("mismatch", [True, False])
-def test_check_kwargs_shape(sim_args, axis, kwargs_ndim, sigs_ndim, mismatch):
+def test_check_kwargs_shape(sim_args, axis, sigs_ndim, mismatch):
 
     sigs = np.array([sim_args['sig']] * 2)
     if sigs_ndim == 3:
@@ -33,20 +32,18 @@ def test_check_kwargs_shape(sim_args, axis, kwargs_ndim, sigs_ndim, mismatch):
     kwargs = [{'center_extrema': 'peak'}]
 
     # 2D cases that will pass
-    if (sigs_ndim == 2 and axis == 1 and kwargs_ndim == 1) or \
-       (sigs_ndim == 2 and axis == None and kwargs_ndim == 1):
+    if sigs_ndim == 2 and (axis == 0 or axis==None):
         kwargs = kwargs * 2
     # 3D cases that will pass
-    elif (sigs_ndim == 3 and axis == 0 and kwargs_ndim == 1) or \
-         (sigs_ndim == 3 and axis == 1 and kwargs_ndim == 1):
+    elif sigs_ndim == 3 and (axis == 0 or axis == 1):
         kwargs =  kwargs * 2
-    elif sigs_ndim == 3 and axis == 2 and kwargs_ndim == 2:
+    elif sigs_ndim == 3 and axis == (0, 1):
         kwargs = [kwargs * 2] * 2
     else:
         mismatch = True
 
     # If not one of the above cases, force size mismatch
-    kwargs = kwargs * 5 if mismatch else kwargs
+    kwargs = [kwargs] * 5 if mismatch else kwargs
 
     if mismatch is True:
         try:
@@ -57,5 +54,12 @@ def test_check_kwargs_shape(sim_args, axis, kwargs_ndim, sigs_ndim, mismatch):
     else:
         check_kwargs_shape(sigs, np.array(kwargs), axis)
 
-    # Check case where to kwargs are passed
+    # Check case where kwargs are passed as dict
     check_kwargs_shape(sigs, {}, axis)
+
+    # Check case where kwargs are passed as 3D list
+    try:
+        check_kwargs_shape(sigs, np.array([[[{}]*2]*2]*2), axis)
+        assert False
+    except ValueError:
+        assert True

--- a/bycycle/tests/group/test_utils.py
+++ b/bycycle/tests/group/test_utils.py
@@ -1,6 +1,6 @@
 """Test group utility functions."""
 
-from pytest import mark, param
+import pytest
 import numpy as np
 
 from bycycle.group.utils import progress_bar, check_kwargs_shape
@@ -8,7 +8,8 @@ from bycycle.group.utils import progress_bar, check_kwargs_shape
 ###################################################################################################
 ###################################################################################################
 
-@mark.parametrize("progress", [None, 'tqdm', param('invalid', marks=mark.xfail)])
+@pytest.mark.parametrize("progress", [None, 'tqdm', pytest.param('invalid',
+                                                                 marks=pytest.mark.xfail)])
 def test_progress_bar(progress):
 
     n_iterations = 10
@@ -19,10 +20,10 @@ def test_progress_bar(progress):
     assert len(pbar) == n_iterations
 
 
-@mark.parametrize("axis", [0, 1, (0, 1), None, param(2, marks=mark.xfail)])
-@mark.parametrize("kwargs_ndim", [1, 2])
-@mark.parametrize("sigs_ndim", [2, 3])
-@mark.parametrize("mismatch", [True, False])
+@pytest.mark.parametrize("axis", [0, 1, 2, None, pytest.param(2, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("kwargs_ndim", [1, 2])
+@pytest.mark.parametrize("sigs_ndim", [2, 3])
+@pytest.mark.parametrize("mismatch", [True, False])
 def test_check_kwargs_shape(sim_args, axis, kwargs_ndim, sigs_ndim, mismatch):
 
     sigs = np.array([sim_args['sig']] * 2)
@@ -31,15 +32,16 @@ def test_check_kwargs_shape(sim_args, axis, kwargs_ndim, sigs_ndim, mismatch):
 
     kwargs = [{'center_extrema': 'peak'}]
 
-    # Cases that will pass
-    if ((axis == 0 or axis == 1) and kwargs_ndim == 1 and sigs_ndim == 3) or \
-       (axis == None and kwargs_ndim == 1 and sigs_ndim == 2):
+    # 2D cases that will pass
+    if (sigs_ndim == 2 and axis == 1 and kwargs_ndim == 1) or \
+       (sigs_ndim == 2 and axis == None and kwargs_ndim == 1):
         kwargs = kwargs * 2
-    elif (axis == (0, 1) or axis == None) and kwargs_ndim == 1 and sigs_ndim == 3:
-        kwargs = kwargs * 4
-    elif (axis == (0, 1) or axis == None) and kwargs_ndim == 2 and sigs_ndim == 3:
-        kwargs = kwargs * 2
-        kwargs = [kwargs] * 2
+    # 3D cases that will pass
+    elif (sigs_ndim == 3 and axis == 0 and kwargs_ndim == 1) or \
+         (sigs_ndim == 3 and axis == 1 and kwargs_ndim == 1):
+        kwargs =  kwargs * 2
+    elif sigs_ndim == 3 and axis == 2 and kwargs_ndim == 2:
+        kwargs = [kwargs * 2] * 2
     else:
         mismatch = True
 

--- a/bycycle/tests/group/test_utils.py
+++ b/bycycle/tests/group/test_utils.py
@@ -1,15 +1,14 @@
 """Test group utility functions."""
 
-import pytest
+from pytest import mark, param
 import numpy as np
 
-from bycycle.group.utils import progress_bar
+from bycycle.group.utils import progress_bar, check_kwargs_shape
 
 ###################################################################################################
 ###################################################################################################
 
-@pytest.mark.parametrize("progress", [None, 'tqdm',
-                                      pytest.param('invalid', marks=pytest.mark.xfail)])
+@mark.parametrize("progress", [None, 'tqdm', param('invalid', marks=mark.xfail)])
 def test_progress_bar(progress):
 
     n_iterations = 10
@@ -18,3 +17,43 @@ def test_progress_bar(progress):
     pbar = progress_bar(iterable, progress, n_iterations)
 
     assert len(pbar) == n_iterations
+
+
+@mark.parametrize("axis", [0, 1, (0, 1), None, param(2, marks=mark.xfail)])
+@mark.parametrize("kwargs_ndim", [1, 2])
+@mark.parametrize("sigs_ndim", [2, 3])
+@mark.parametrize("mismatch", [True, False])
+def test_check_kwargs_shape(sim_args, axis, kwargs_ndim, sigs_ndim, mismatch):
+
+    sigs = np.array([sim_args['sig']] * 2)
+    if sigs_ndim == 3:
+        sigs = np.array([sigs] * 2)
+
+    kwargs = [{'center_extrema': 'peak'}]
+
+    # Cases that will pass
+    if ((axis == 0 or axis == 1) and kwargs_ndim == 1 and sigs_ndim == 3) or \
+       (axis == None and kwargs_ndim == 1 and sigs_ndim == 2):
+        kwargs = kwargs * 2
+    elif (axis == (0, 1) or axis == None) and kwargs_ndim == 1 and sigs_ndim == 3:
+        kwargs = kwargs * 4
+    elif (axis == (0, 1) or axis == None) and kwargs_ndim == 2 and sigs_ndim == 3:
+        kwargs = kwargs * 2
+        kwargs = [kwargs] * 2
+    else:
+        mismatch = True
+
+    # If not one of the above cases, force size mismatch
+    kwargs = kwargs * 5 if mismatch else kwargs
+
+    if mismatch is True:
+        try:
+            check_kwargs_shape(sigs, np.array(kwargs), axis)
+            assert False
+        except ValueError:
+            assert True
+    else:
+        check_kwargs_shape(sigs, np.array(kwargs), axis)
+
+    # Check case where to kwargs are passed
+    check_kwargs_shape(sigs, {}, axis)

--- a/bycycle/tests/plts/test_burst.py
+++ b/bycycle/tests/plts/test_burst.py
@@ -18,14 +18,13 @@ from bycycle.plts import *
 @pytest.mark.parametrize("interp", [True, False])
 def test_plot_burst_detect_param(sim_args, interp):
 
-    df_samples = sim_args['df_samples']
     df_features = sim_args['df_features']
     sig = sim_args['sig']
     fs = sim_args['fs']
 
     thresh = np.nanmin(df_features['amp_consistency'].values) + 0.1
 
-    plot_burst_detect_param(df_features, df_samples, sig, fs, 'amp_consistency',
+    plot_burst_detect_param(df_features, sig, fs, 'amp_consistency',
                             thresh, interp=interp, save_fig=True,
                             file_path=TEST_PLOTS_PATH, file_name='test_plot_burst_detect_param')
 
@@ -40,14 +39,13 @@ def test_plot_burst_detect_summary(sim_args, plot_only_result):
                               'monotonicity_threshold': .8,
                               'min_n_cycles': 3}
 
-    df_samples = sim_args['df_samples']
     df_features = sim_args['df_features']
     sig = sim_args['sig']
     fs = sim_args['fs']
 
     df_features = detect_bursts_cycles(df_features, **burst_detection_kwargs)
 
-    plot_burst_detect_summary(df_features, df_samples, sig, fs, burst_detection_kwargs,
+    plot_burst_detect_summary(df_features, sig, fs, burst_detection_kwargs,
                               plot_only_result=plot_only_result,
                               save_fig=True, file_path=TEST_PLOTS_PATH,
                               file_name='test_plot_burst_detect_summary')

--- a/bycycle/tests/plts/test_cyclepoints.py
+++ b/bycycle/tests/plts/test_cyclepoints.py
@@ -13,7 +13,7 @@ from bycycle.plts.cyclepoints import *
 @plot_test
 def test_plot_cyclepoints_df(sim_args):
 
-    plot_cyclepoints_df(sim_args['df_samples'], sim_args['sig'], sim_args['fs'], save_fig=True,
+    plot_cyclepoints_df(sim_args['df_features'], sim_args['sig'], sim_args['fs'], save_fig=True,
                         file_name='test_plot_cyclepoints_df', file_path=TEST_PLOTS_PATH)
 
 

--- a/bycycle/tests/utils/test_dataframes.py
+++ b/bycycle/tests/utils/test_dataframes.py
@@ -1,5 +1,6 @@
 """Tests for utils.dataframe."""
 
+from copy import deepcopy
 import numpy as np
 import pandas as pd
 
@@ -10,12 +11,12 @@ from bycycle.utils.dataframes import *
 
 def test_limit_df(sim_args):
 
-    df_samples = sim_args['df_samples']
+    df_features = sim_args['df_features']
     fs = sim_args['fs']
 
     xlim = (1, 2)
 
-    df_short = limit_df(df_samples, fs, start=xlim[0], stop=xlim[1])
+    df_short = limit_df(df_features, fs, start=xlim[0], stop=xlim[1])
 
     assert df_short['sample_next_trough'].min() >= 0
     assert df_short['sample_last_trough'].max() <= fs * (xlim[1] - xlim[0])
@@ -23,15 +24,40 @@ def test_limit_df(sim_args):
 
 def test_get_extrema_df(sim_args):
 
-    df_samples = sim_args['df_samples']
-    center_e, side_e = get_extrema_df(df_samples)
+    df_features = sim_args['df_features']
+    center_e, side_e = get_extrema_df(df_features)
 
     # The fixture will return peak centered cycles
     assert center_e == 'peak'
     assert side_e == 'trough'
 
-    df_samples = pd.DataFrame({'sample_trough': []})
-    center_e, side_e = get_extrema_df(df_samples)
+    df_features = pd.DataFrame({'sample_trough': []})
+    center_e, side_e = get_extrema_df(df_features)
 
     assert center_e == 'trough'
     assert side_e == 'peak'
+
+
+def test_rename_extrema_df(sim_args):
+
+    df_features = sim_args['df_features']
+
+    # Remove column names that will not change based on extrema center
+    same_cols = ['amp_fraction', 'amp_consistency', 'period_consistency',
+                 'monotonicity', 'band_amp', 'period', 'volt_amp',
+                 'is_burst']
+
+    df_features = df_features.drop(same_cols, axis=1)
+
+    # Rename columns
+    df_features_renamed = rename_extrema_df('trough', deepcopy(df_features), return_samples=True)
+
+    # These columns names don't change, but their values do
+    diff_cols = ['time_rdsym', 'time_ptsym']
+
+    for diff_col in diff_cols:
+
+        assert (df_features_renamed.pop(diff_col).values == \
+            df_features.pop(diff_col).values).all()
+
+    assert (df_features.columns.values != df_features_renamed.columns.values).all()

--- a/bycycle/tests/utils/test_dataframes.py
+++ b/bycycle/tests/utils/test_dataframes.py
@@ -1,6 +1,10 @@
 """Tests for utils.dataframe."""
 
 from copy import deepcopy
+
+from pytest import mark, param
+
+import numpy as np
 import pandas as pd
 
 from bycycle.utils.dataframes import *
@@ -96,3 +100,26 @@ def test_epoch_df(sim_args):
     dfs_features = epoch_df(df_features, len(sig), epoch_len)
 
     assert len(dfs_features) == int(len(sig) / epoch_len)
+
+
+@mark.parametrize("mismatch", [False, param(True, marks=mark.xfail)])
+@mark.parametrize("ndim", [2, 3])
+def test_flatten_dfs(sim_args, mismatch, ndim):
+
+    df_features_orig = sim_args['df_features']
+
+    if ndim == 2:
+        dfs_features = [df_features_orig.copy(), df_features_orig.copy()]
+        labels = ['A', 'B']
+    elif ndim == 3:
+        dfs_features = [[df_features_orig.copy(), df_features_orig.copy()],
+                        [df_features_orig.copy(), df_features_orig.copy()]]
+        labels = [['CH00_EP00', 'CH00_EP01'], ['CH01_EP00', 'CH01_EP01']]
+
+    if mismatch:
+        labels = ['A']
+
+    df_features = flatten_dfs(dfs_features, labels)
+
+    assert 'Label' in df_features.columns
+    assert (np.unique(df_features['Label'].values) == np.array(labels).flatten()).all()

--- a/bycycle/tests/utils/test_dataframes.py
+++ b/bycycle/tests/utils/test_dataframes.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 
-from pytest import mark, param
+import pytest
 
 import numpy as np
 import pandas as pd
@@ -102,8 +102,8 @@ def test_epoch_df(sim_args):
     assert len(dfs_features) == int(len(sig) / epoch_len)
 
 
-@mark.parametrize("mismatch", [False, param(True, marks=mark.xfail)])
-@mark.parametrize("ndim", [2, 3])
+@pytest.mark.parametrize("mismatch", [False, pytest.param(True, marks=pytest.mark.xfail)])
+@pytest.mark.parametrize("ndim", [2, 3])
 def test_flatten_dfs(sim_args, mismatch, ndim):
 
     df_features_orig = sim_args['df_features']

--- a/bycycle/tests/utils/test_dataframes.py
+++ b/bycycle/tests/utils/test_dataframes.py
@@ -61,3 +61,17 @@ def test_rename_extrema_df(sim_args):
             df_features.pop(diff_col).values).all()
 
     assert (df_features.columns.values != df_features_renamed.columns.values).all()
+
+
+def test_split_samples_df(sim_args):
+
+    df_features = sim_args['df_features']
+
+    df_features, df_samples = split_samples_df(df_features)
+
+    # Ensure sample columns are isolated to df_samples
+    for col in df_features.columns:
+        assert "sample_" not in col
+
+    for col in df_samples.columns:
+        assert "sample_" in col

--- a/bycycle/tests/utils/test_dataframes.py
+++ b/bycycle/tests/utils/test_dataframes.py
@@ -1,7 +1,6 @@
 """Tests for utils.dataframe."""
 
 from copy import deepcopy
-import numpy as np
 import pandas as pd
 
 from bycycle.utils.dataframes import *
@@ -67,7 +66,7 @@ def test_split_samples_df(sim_args):
 
     df_features = sim_args['df_features']
 
-    df_features, df_samples = split_samples_df(df_features)
+    df_features, df_samples = split_samples_df(df_features.copy())
 
     # Ensure sample columns are isolated to df_samples
     for col in df_features.columns:
@@ -75,3 +74,25 @@ def test_split_samples_df(sim_args):
 
     for col in df_samples.columns:
         assert "sample_" in col
+
+
+def test_drop_samples_df(sim_args):
+
+    df_features = sim_args['df_features']
+
+    df_features = drop_samples_df(df_features.copy())
+
+    for col in df_features.columns:
+        assert "sample_" not in col
+
+
+def test_epoch_df(sim_args):
+
+    sig = sim_args['sig']
+    df_features = sim_args['df_features']
+    epoch_len = sim_args['fs']
+
+    print(df_features.columns)
+    dfs_features = epoch_df(df_features, len(sig), epoch_len)
+
+    assert len(dfs_features) == int(len(sig) / epoch_len)

--- a/bycycle/utils/__init__.py
+++ b/bycycle/utils/__init__.py
@@ -2,3 +2,4 @@
 
 from .timeseries import limit_signal
 from .dataframes import limit_df, get_extrema_df, rename_extrema_df
+from .checks import check_param

--- a/bycycle/utils/__init__.py
+++ b/bycycle/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utilities."""
 
 from .timeseries import limit_signal
-from .dataframes import limit_df, get_extrema_df, rename_extrema_df
+from .dataframes import (limit_df, get_extrema_df, rename_extrema_df,
+                         split_samples_df, drop_samples_df, epoch_df, flatten_dfs)
 from .checks import check_param

--- a/bycycle/utils/dataframes.py
+++ b/bycycle/utils/dataframes.py
@@ -215,6 +215,17 @@ def drop_samples_df(df_features):
     -------
     df_features : pandas.DataFrame
         A dataframe without sample indices columns removed.
+
+    Examples
+    --------
+    Drop cyclepoint sample columns from a dataframe:
+
+    >>> from neurodsp.sim import sim_bursty_oscillation
+    >>> from bycycle.features import compute_features
+    >>> fs = 500
+    >>> sig = sim_bursty_oscillation(10, fs, freq=10)
+    >>> df_features = compute_features(sig, fs, f_range=(8, 12), center_extrema='peak')
+    >>> df_features = drop_samples_df(df_features)
     """
 
     sample_columns = [col for col in df_features.columns if col.startswith('sample_')]
@@ -239,6 +250,17 @@ def epoch_df(df_features, sig_len, epoch_len):
     -------
     dfs_features : list of pd.DataFrame
         A list of features dataframes that have been epoched.
+
+    Examples
+    --------
+    Epoch a dataframe in 1 seconds intervals:
+
+    >>> from neurodsp.sim import sim_bursty_oscillation
+    >>> from bycycle.features import compute_features
+    >>> fs = 500
+    >>> sig = sim_bursty_oscillation(10, fs, freq=10)
+    >>> df_features = compute_features(sig, fs, f_range=(8, 12), center_extrema='peak')
+    >>> dfs_features = epoch_df(df_features, len(sig), fs)
     """
 
     # Reshape the dataframe into original sigs shape
@@ -285,6 +307,19 @@ def flatten_dfs(dfs_features, labels, column_name='Label'):
     -------
     df_features : pd.DataFrame
         A single dataframe containing 1 or 2 group columns.
+
+    Examples
+    --------
+    Flatten an epoched a dataframe:
+
+    >>> from neurodsp.sim import sim_bursty_oscillation
+    >>> from bycycle.features import compute_features
+    >>> from bycycle.utils.dataframes import epoch_df
+    >>> fs = 500
+    >>> sig = sim_bursty_oscillation(10, fs, freq=10)
+    >>> df_features = compute_features(sig, fs, f_range=(8, 12), center_extrema='peak')
+    >>> dfs_features = epoch_df(df_features, len(sig), fs)
+    >>> df_features = flatten_dfs(dfs_features, ["{sec}s".format(sec=sec) for sec in range(10)])
     """
 
     labels = np.array(labels) if isinstance(labels, list) else labels
@@ -318,7 +353,3 @@ def flatten_dfs(dfs_features, labels, column_name='Label'):
         df_features = pd.concat([df for dfs in dfs_features for df in dfs])
 
     return df_features
-
-
-
-

--- a/bycycle/utils/dataframes.py
+++ b/bycycle/utils/dataframes.py
@@ -110,11 +110,11 @@ def rename_extrema_df(center_extrema, df_features, return_samples=True):
     ----------
     center_extrema : {'trough', 'peak'}
         Which extrema is centered.
-    df_shape_features : pandas.DataFrames
+    df_features : pandas.DataFrames
         Bycycle dataframes to rename, given the centered extrema.
     return_samples : bool, optional, default: True
         Whether to rename sample columns if ``returns_samples`` is True when computing
-        ``df_shape_features`` using :func:`~.compute_shape_features`.
+        ``df_features`` using :func:`~.compute_features`.
 
     Returns
     -------
@@ -196,6 +196,73 @@ def split_samples_df(df_features):
     """
 
     df_samples = pd.concat([df_features.pop(col) for col in df_features.columns.values \
-        if "sample_" in col], axis=1)
+        if col.startswith('sample_')], axis=1)
 
     return df_features, df_samples
+
+
+def drop_samples_df(df_features):
+    """Remove cyclepoints sample columns from a dataframe.
+
+    Parameters
+    ----------
+    df_features : pandas.DataFrame
+        Dataframe output of :func:`~.compute_features` or :func`~.compute_shape_features`.
+
+    Returns
+    -------
+    df_features : pandas.DataFrame
+        A dataframe without sample indices columns removed.
+    """
+
+    sample_columns = [col for col in df_features.columns if col.startswith('sample_')]
+    df_features = df_features.drop(sample_columns, axis=1)
+
+    return df_features
+
+
+def epoch_df(df_features, sig_len, epoch_len):
+    """Reshape a dataframe into a list of dataframes.
+
+    Parameters
+    ----------
+    df_features : pandas.DataFrame
+        A dataframe containing shape and burst features for each cycle.
+    sig_len : int
+        Length of a 1D time series.
+    epoch_len : int
+        The length of each epoched data in units of signal samples.
+
+    Returns
+    -------
+    dfs_features : list of pd.DataFrame
+        A list of features dataframes that have been epoched.
+    """
+
+    # Reshape the dataframe into original sigs shape
+    center_extrema, _ = get_extrema_df(df_features)
+    last_sample = 'sample_next_trough' if center_extrema == 'peak' else 'sample_next_peak'
+
+    dfs_features = []
+    sig_last_idxs = np.arange(epoch_len, sig_len + epoch_len, epoch_len)
+    sig_first_idxs = np.append(0, sig_last_idxs[:-1])
+
+    for first_idx, last_idx in zip(sig_first_idxs, sig_last_idxs):
+
+        # Get the range for each df
+        idx_range = np.where((df_features[last_sample].values <= last_idx) & \
+                                (df_features[last_sample].values > first_idx))[0]
+
+        df_single = df_features.iloc[idx_range]
+        df_single.reset_index(drop=True, inplace=True)
+
+        # Shift sample indices
+        sample_cols = [col for col in df_single.columns if 'sample_' in col]
+
+        for col in sample_cols:
+            df_single[col] = df_single[col] - first_idx
+
+        dfs_features.append(df_single)
+
+    return dfs_features
+

--- a/bycycle/utils/dataframes.py
+++ b/bycycle/utils/dataframes.py
@@ -1,6 +1,7 @@
 """Utility functions for working with ByCycle DataFrames."""
 
 import numpy as np
+import pandas as pd
 
 from bycycle.utils.checks import check_param
 
@@ -165,3 +166,36 @@ def rename_extrema_df(center_extrema, df_features, return_samples=True):
             df_features.rename(columns=samples_rename_dict, inplace=True)
 
     return df_features
+
+
+def split_samples_df(df_features):
+    """Move cyclepoints sample indices columns to a separate dataframe.
+
+    Parameters
+    ----------
+    df_features : pandas.DataFrame
+        Dataframe output of :func:`~.compute_features` or :func`~.compute_shape_features`.
+
+    Returns
+    -------
+    df_features : pandas.DataFrame
+        A dataframe without sample indices columns removed.
+    df_samples : pandas.DataFrame
+        A dataframe only containing sample indices columns.
+
+    Examples
+    --------
+    Separate sample/signal indices into a separate dataframe:
+
+    >>> from neurodsp.sim import sim_bursty_oscillation
+    >>> from bycycle.features import compute_features
+    >>> fs = 500
+    >>> sig = sim_bursty_oscillation(10, fs, freq=10)
+    >>> df_features = compute_features(sig, fs, f_range=(8, 12), center_extrema='peak')
+    >>> df_features, df_samples = split_samples_df(df_features)
+    """
+
+    df_samples = pd.concat([df_features.pop(col) for col in df_features.columns.values \
+        if "sample_" in col], axis=1)
+
+    return df_features, df_samples

--- a/bycycle/version.py
+++ b/bycycle/version.py
@@ -1,1 +1,2 @@
+"""Set the current pypi version"""
 __version__ = '1.0.0rc1'

--- a/tutorials/plot_2_bycycle_algorithm.py
+++ b/tutorials/plot_2_bycycle_algorithm.py
@@ -140,10 +140,10 @@ plot_cyclepoints_array(sig_low, fs, xlim=(13, 14), peaks=peaks, troughs=troughs,
 # 3. Compute features of each cycle
 # ---------------------------------
 # After these 4 points of each cycle are localized, we compute some simple statistics for each
-# cycle. The main cycle-by-cycle function, :func:`~.compute_features`, returns two dataframes:
-# one for cycle features and one for locating cyclepoints in the signal. Each entry or row in either
-# dataframe is a cycle and each column is a property of that cycle (see table below). The four
-# main features are:
+# cycle. The main cycle-by-cycle function, :func:`~.compute_features`, returns a dataframe
+# containing cycle features and sample locations of cyclepoints in the signal. Each entry or row
+# in either dataframe is a cycle and each column is a property of that cycle (see table below). The
+# four main features are:
 #
 # - amplitude (volt_amp) - average voltage change of the rise and decay
 # - period (period) - time between consecutive troughs (or peaks, if default is changed)
@@ -155,15 +155,11 @@ plot_cyclepoints_array(sig_low, fs, xlim=(13, 14), peaks=peaks, troughs=troughs,
 
 ####################################################################################################
 
-df_features, df_samples = compute_features(sig, fs, f_theta)
+df_features = compute_features(sig, fs, f_theta)
 
 ####################################################################################################
 
 df_features
-
-####################################################################################################
-
-df_samples
 
 ####################################################################################################
 #
@@ -254,9 +250,9 @@ threshold_kwargs = {'amp_fraction_threshold': 0,
                     'monotonicity_threshold': .7,
                     'min_n_cycles': 3}
 
-df_features, df_samples = compute_features(sig, fs, f_alpha, threshold_kwargs=threshold_kwargs)
+df_features = compute_features(sig, fs, f_alpha, threshold_kwargs=threshold_kwargs)
 
-plot_burst_detect_summary(df_features, df_samples, sig, fs, threshold_kwargs, figsize=(16, 3))
+plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, figsize=(16, 3))
 
 ####################################################################################################
 #
@@ -271,9 +267,9 @@ threshold_kwargs = {'amp_fraction_threshold': 0,
                     'monotonicity_threshold': .9,
                     'min_n_cycles': 3}
 
-df_features, df_samples = compute_features(sig, fs, f_alpha, threshold_kwargs=threshold_kwargs)
+df_features = compute_features(sig, fs, f_alpha, threshold_kwargs=threshold_kwargs)
 
-plot_burst_detect_summary(df_features, df_samples, sig, fs, threshold_kwargs, figsize=(16, 3))
+plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, figsize=(16, 3))
 
 ####################################################################################################
 #
@@ -292,6 +288,6 @@ threshold_kwargs = {'amp_fraction_threshold': .3,
                     'monotonicity_threshold': .8,
                     'min_n_cycles': 3}
 
-df_features, df_samples = compute_features(sig, fs, f_alpha, threshold_kwargs=threshold_kwargs)
+df_features = compute_features(sig, fs, f_alpha, threshold_kwargs=threshold_kwargs)
 
-plot_burst_detect_summary(df_features, df_samples, sig, fs, threshold_kwargs, figsize=(16, 3))
+plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, figsize=(16, 3))

--- a/tutorials/plot_3_bycycle_resting_state.py
+++ b/tutorials/plot_3_bycycle_resting_state.py
@@ -89,8 +89,7 @@ threshold_kwargs = {'amp_fraction_threshold': .2,
 # Compute features for each signal
 compute_features_kwargs={'threshold_kwargs': threshold_kwargs}
 
-df_features_list = compute_features_2d(sigs, fs, f_alpha,
-                                       compute_features_kwargs=compute_features_kwargs)
+df_features_list = compute_features_2d(sigs, fs, f_alpha, compute_features_kwargs)
 
 # Add group and subject ids to dataframes
 groups = ['patient' if idx >= int(n_signals/2) else 'control' for idx in range(n_signals)]
@@ -116,7 +115,7 @@ df_features.head()
 # periods of the signal that appear to be bursting. This was confirmed by looking at a few different
 # signal segments from a few subjects.
 
-plot_burst_detect_summary(df_features_list[1], sigs[0], fs, threshold_kwargs,
+plot_burst_detect_summary(df_features_list[0], sigs[0], fs, threshold_kwargs,
                           xlim=(0, 5), figsize=(16, 3))
 
 ####################################################################################################

--- a/tutorials/plot_3_bycycle_resting_state.py
+++ b/tutorials/plot_3_bycycle_resting_state.py
@@ -89,8 +89,8 @@ threshold_kwargs = {'amp_fraction_threshold': .2,
 # Compute features for each signal
 compute_features_kwargs={'threshold_kwargs': threshold_kwargs}
 
-df_features_list, df_samples_list = \
-    compute_features_2d(sigs, fs, f_alpha, compute_features_kwargs=compute_features_kwargs)
+df_features_list = compute_features_2d(sigs, fs, f_alpha,
+                                       compute_features_kwargs=compute_features_kwargs)
 
 # Add group and subject ids to dataframes
 groups = ['patient' if idx >= int(n_signals/2) else 'control' for idx in range(n_signals)]
@@ -116,8 +116,8 @@ df_features.head()
 # periods of the signal that appear to be bursting. This was confirmed by looking at a few different
 # signal segments from a few subjects.
 
-plot_burst_detect_summary(df_features_list[1], df_samples_list[1], sigs[1], fs,
-                          threshold_kwargs, xlim=(0, 5), figsize=(16, 3))
+plot_burst_detect_summary(df_features_list[1], sigs[0], fs, threshold_kwargs,
+                          xlim=(0, 5), figsize=(16, 3))
 
 ####################################################################################################
 #


### PR DESCRIPTION
**2d Array**
This addresses a point in #76 and is built on top of #75 (i.e. starting from deabc11). It allows for 2d arrays to be flatten prior to computing features using `axis = None`. The resulting dataframe is split into a list of dfs corresponding to indices in the original 2d signal. This is to address edge artifacts and features miscalculations from ignoring the influence of other signals.

For example flattening 2d to 1d (`axis=None`), or treating each signal separately (`axis=0`) will result in different burst fractions (`compute_burst_fraction`):
```
df_shape_features['volt_amp'].rank() / len(df_shape_features)
```

 - ``axis=1`` : Iterates over each row/signal in an array independently (i.e. for each channel
   in (n_channels, n_timepoints)).
 - ``axis=None`` : Flattens rows/signals prior to computing features (i.e. across flatten epochs
   in (n_epochs, n_timepoints)).

Another note, is that when  `axis = None`, the 2d to 1d array conversion prevents parallelization.

**3d Array**
An axis kwarg may be passed in `compute_features_3d`:

 - ``axis=0`` : Iterates over 2D slices along the zeroth dimension, (i.e. for each channel in
   (n_channels, n_epochs, n_timepoints)).
 - ``axis=1`` : Iterates over 2D slices along the first dimension (i.e. across flatten epochs in
   (n_epochs, n_timepoints)).
 - ``axis=(0, 1)`` : Iterates over 1D slices along the zeroth and first dimension (i.e across
   each signal independently in (n_participants, n_channels, n_timepoints)).
