### PR TITLE
[BUG] Limit Dataframe Fix

### DIFF
--- a/bycycle/plts/cyclepoints.py
+++ b/bycycle/plts/cyclepoints.py
@@ -135,10 +135,10 @@ def plot_cyclepoints_array(sig, fs, peaks=None, troughs=None, rises=None, decays
 
     # Set times and limits
     times = np.arange(0, len(sig) / fs, 1 / fs)
-    xlim = (times[0], times[-1]) if xlim is None else xlim
 
     # Restrict sig and times to xlim
-    sig, times = limit_signal(times, sig, start=xlim[0], stop=xlim[1])
+    if xlim is not None:
+        sig, times = limit_signal(times, sig, start=xlim[0], stop=xlim[1])
 
     # Set default kwargs
     figsize = kwargs.pop('figsize', (15, 3))
@@ -156,8 +156,8 @@ def plot_cyclepoints_array(sig, fs, peaks=None, troughs=None, rises=None, decays
         if points is not None:
 
             # Limit times and shift indices of cyclepoints (cps)
-            cps = points[(points >= xlim[0]*fs) & (points < xlim[1]*fs)]
-            cps = cps - int(xlim[0]*fs)
+            cps = points[(points >= times[0]*fs) & (points < times[-1]*fs)]
+            cps = cps - int(times[0]*fs)
 
             y_values.append(sig[cps])
             x_values.append(times[cps])

--- a/bycycle/utils/dataframes.py
+++ b/bycycle/utils/dataframes.py
@@ -55,10 +55,10 @@ def limit_df(df, fs, start=None, stop=None):
 
     start = 0 if start is None else start
 
-    df = df[df['sample_next_' + side_e].values >= start*fs]
+    df = df[df['sample_last_' + side_e].values >= start*fs]
 
     if stop is not None:
-        df = df[df['sample_last_' + side_e].values < stop*fs]
+        df = df[df['sample_next_' + side_e].values <= stop*fs]
 
     # Shift sample indices to start at 0
     df['sample_last_' + side_e] = df['sample_last_' + side_e] - int(fs * start)


### PR DESCRIPTION
There was a bug when using `xlim` with plotting funcs. Is was a mix up of `df['sample_last_' + side_e]` and `df['sample_next_' + side_e]` in the `limit_df` func. Here's an example:

```python
import numpy as np
from bycycle.features import compute_features
from bycycle.plts import plot_burst_detect_summary

n_seconds = 10
fs = 1000

sig = np.random.rand(int(n_seconds * fs))
times = np.arange(0, len(sig)/fs, 1/fs)

thresholds = {'amp_fraction_threshold': 0.5,
              'amp_consistency_threshold': 0.5,
              'period_consistency_threshold': 0.5,
              'monotonicity_threshold': 0.75,
              'min_n_cycles': 3}

df_features = compute_features(sig, fs, (1, 50), threshold_kwargs=thresholds)
plot_burst_detect_summary(df_features, sig, fs, thresholds, xlim=(1, 2))
```