### PR TITLE
[ENH] Recompute consistency features at burst edges

### DIFF
--- a/bycycle/burst/amp.py
+++ b/bycycle/burst/amp.py
@@ -1,6 +1,6 @@
 """Detect bursts: amplitude threshold approach."""
 
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range
 from bycycle.burst.utils import check_min_burst_cycles
 
 ###################################################################################################
@@ -38,7 +38,7 @@ def detect_bursts_amp(df_features, burst_fraction_threshold=1, min_n_cycles=3):
     """
 
     # Ensure arguments are within valid ranges
-    check_param(burst_fraction_threshold, 'burst_fraction_threshold', (0, 1))
+    check_param_range(burst_fraction_threshold, 'burst_fraction_threshold', (0, 1))
 
     # Determine cycles that are defined as bursting throughout the whole cycle
     is_burst = [frac >= burst_fraction_threshold for frac in df_features['burst_fraction']]

--- a/bycycle/burst/cycle.py
+++ b/bycycle/burst/cycle.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range
 from bycycle.burst.utils import check_min_burst_cycles
 
 ###################################################################################################
@@ -77,10 +77,10 @@ def detect_bursts_cycles(df_features, amp_fraction_threshold=0., amp_consistency
     """
 
     # Ensure arguments are within valid ranges
-    check_param(amp_fraction_threshold, 'amp_fraction_threshold', (0, 1))
-    check_param(amp_consistency_threshold, 'amp_consistency_threshold', (0, 1))
-    check_param(period_consistency_threshold, 'period_consistency_threshold', (0, 1))
-    check_param(monotonicity_threshold, 'monotonicity_threshold', (0, 1))
+    check_param_range(amp_fraction_threshold, 'amp_fraction_threshold', (0, 1))
+    check_param_range(amp_consistency_threshold, 'amp_consistency_threshold', (0, 1))
+    check_param_range(period_consistency_threshold, 'period_consistency_threshold', (0, 1))
+    check_param_range(monotonicity_threshold, 'monotonicity_threshold', (0, 1))
 
     # Compute if each period is part of an oscillation
     amp_fraction = df_features['amp_fraction'] > amp_fraction_threshold

--- a/bycycle/burst/utils.py
+++ b/bycycle/burst/utils.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 import numpy as np
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range, check_param_options
 
 ####################################################################################################
 ####################################################################################################
@@ -32,7 +32,7 @@ def check_min_burst_cycles(is_burst, min_n_cycles=3):
     """
 
     # Ensure argument is within valid range
-    check_param(min_n_cycles, 'min_n_cycles', (0, np.inf))
+    check_param_range(min_n_cycles, 'min_n_cycles', (0, np.inf))
 
     temp_cycle_count = 0
 
@@ -136,6 +136,9 @@ def recompute_edge(df_features, cyc_idx, direction):
     df_features : pandas.DataFrame
         A dataframe with updated consistency features.
     """
+
+    # Check that param validity
+    check_param_options(direction, 'direction', ['both', 'next', 'last'])
 
     # Prevent circular imports between burst.utils and burst.cycle
     from bycycle.features.burst import compute_amp_consistency, compute_period_consistency

--- a/bycycle/cyclepoints/extrema.py
+++ b/bycycle/cyclepoints/extrema.py
@@ -5,7 +5,7 @@ import numpy as np
 from neurodsp.filt import filter_signal
 from neurodsp.filt.fir import compute_filter_length
 
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range
 from bycycle.cyclepoints.zerox import find_flank_zerox
 
 ###################################################################################################
@@ -60,7 +60,7 @@ def find_extrema(sig, fs, f_range, boundary=0, first_extrema='peak',
     """
 
     # Ensure arguments are within valid range
-    check_param(fs, 'fs', (0, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
 
     # Set default filtering parameters
     if filter_kwargs is None:

--- a/bycycle/features/burst.py
+++ b/bycycle/features/burst.py
@@ -128,14 +128,14 @@ def compute_amp_fraction(df_shape_features):
     return df_shape_features['volt_amp'].rank() / len(df_shape_features)
 
 
-def compute_amp_consistency(df_shape_features, direction=None):
+def compute_amp_consistency(df_shape_features, direction='both'):
     """Compute amplitude consistency for each cycle.
 
     Parameters
     ----------
     df_shape_features : pandas.DataFrame
         Shape features for each cycle, determined using :func:`~.compute_shape_features`.
-    direction : {'next', 'last'}
+    direction : {'both', 'next', 'last'}
         The direction to compute consistency. Defaults to bi-directional.
 
     Returns
@@ -190,20 +190,20 @@ def compute_amp_consistency(df_shape_features, direction=None):
                 amp_consistency[cyc] = np.nanmin([consist_current, consist_next])
             elif direction == 'last':
                 amp_consistency[cyc] = np.nanmin([consist_current, consist_last])
-            else:
+            elif direction == 'both':
                 amp_consistency[cyc] = np.nanmin([consist_current, consist_next, consist_last])
 
     return amp_consistency
 
 
-def compute_period_consistency(df_shape_features, direction=None):
+def compute_period_consistency(df_shape_features, direction='both'):
     """Compute the period consistency of each cycle.
 
     Parameters
     ----------
     df_shape_features : pandas.DataFrame
         Shape features for each cycle, determined using :func:`~.compute_shape_features`.
-    direction : {'next', 'last'}
+    direction : {'both', 'next', 'last'}
         The direction to compute consistency. Defaults to bi-directional.
 
     Returns
@@ -239,7 +239,7 @@ def compute_period_consistency(df_shape_features, direction=None):
             period_consistency[cyc] = consist_next
         elif direction == 'last':
             period_consistency[cyc] = consist_last
-        else:
+        elif direction == 'both':
             period_consistency[cyc] = np.min([consist_next, consist_last])
 
     return period_consistency

--- a/bycycle/features/burst.py
+++ b/bycycle/features/burst.py
@@ -3,14 +3,13 @@
 import numpy as np
 import pandas as pd
 
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range, check_param_options
 from bycycle.burst import detect_bursts_dual_threshold
 
 ###################################################################################################
 ###################################################################################################
 
-def compute_burst_features(df_shape_features, sig, burst_method='cycles',
-                           burst_kwargs=None, direction=None):
+def compute_burst_features(df_shape_features, sig, burst_method='cycles', burst_kwargs=None):
     """Compute burst features for each cycle.
 
     Parameters
@@ -155,6 +154,9 @@ def compute_amp_consistency(df_shape_features, direction='both'):
     >>> amp_consistency = compute_amp_consistency(df_shapes)
     """
 
+    # Check that param validity
+    check_param_options(direction, 'direction', ['both', 'next', 'last'])
+
     # Compute amplitude consistency
     cycles = len(df_shape_features)
     amp_consistency = np.ones(cycles) * np.nan
@@ -222,6 +224,9 @@ def compute_period_consistency(df_shape_features, direction='both'):
     >>> df_shapes = compute_shape_features(sig, fs, f_range=(8, 12))
     >>> period_consistency = compute_period_consistency(df_shapes)
     """
+
+    # Check that param validity
+    check_param_options(direction, 'direction', ['both', 'next', 'last'])
 
     # Compute period consistency
     cycles = len(df_shape_features)
@@ -339,9 +344,9 @@ def compute_burst_fraction(df_samples, sig, fs, f_range, amp_threshes=(1, 2),
     """
 
     # Ensure arguments are within valid ranges
-    check_param(fs, 'fs', (0, np.inf))
-    check_param(amp_threshes[0], 'lower amp_threshes', (0, amp_threshes[1]))
-    check_param(amp_threshes[1], 'upper amp_threshes', (amp_threshes[0], np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
+    check_param_range(amp_threshes[0], 'lower amp_threshes', (0, amp_threshes[1]))
+    check_param_range(amp_threshes[1], 'upper amp_threshes', (amp_threshes[0], np.inf))
 
     filter_kwargs = {} if filter_kwargs is None else filter_kwargs
 

--- a/bycycle/features/cyclepoints.py
+++ b/bycycle/features/cyclepoints.py
@@ -3,7 +3,7 @@
 import pandas as pd
 import numpy as np
 
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range
 from bycycle.cyclepoints import find_extrema, find_zerox
 
 ###################################################################################################
@@ -51,7 +51,7 @@ def compute_cyclepoints(sig, fs, f_range, **find_extrema_kwargs):
     """
 
     # Ensure arguments are within valid range
-    check_param(fs, 'fs', (0, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
 
     # Find extrema and zero-crossings locations in the signal
     peaks, troughs = find_extrema(sig, fs, f_range, **find_extrema_kwargs)

--- a/bycycle/features/features.py
+++ b/bycycle/features/features.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range
 from bycycle.utils.dataframes import drop_samples_df
 from bycycle.features.shape import compute_shape_features
 from bycycle.features.burst import compute_burst_features
@@ -107,7 +107,7 @@ def compute_features(sig, fs, f_range, center_extrema='peak', burst_method='cycl
     """
 
     # Ensure arguments are within valid range
-    check_param(fs, 'fs', (0, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
 
     # Compute shape features for each cycle
     df_shape_features = compute_shape_features(sig, fs, f_range, center_extrema=center_extrema,

--- a/bycycle/features/shape.py
+++ b/bycycle/features/shape.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from neurodsp.timefrequency import amp_by_time
 
-from bycycle.utils import rename_extrema_df, check_param
+from bycycle.utils import rename_extrema_df, check_param_range
 from bycycle.features.cyclepoints import compute_cyclepoints
 
 ###################################################################################################
@@ -79,8 +79,8 @@ def compute_shape_features(sig, fs, f_range, center_extrema='peak',
     """
 
     # Ensure arguments are within valid ranges
-    check_param(fs, 'fs', (0, np.inf))
-    check_param(n_cycles, 'n_cycles', (0, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
+    check_param_range(n_cycles, 'n_cycles', (0, np.inf))
 
     # Set defaults if user input is None
     if find_extrema_kwargs is None:
@@ -312,8 +312,8 @@ def compute_band_amp(df_samples, sig, fs, f_range, n_cycles=3):
     """
 
     # Ensure arguments are within valid ranges
-    check_param(fs, 'fs', (0, np.inf))
-    check_param(n_cycles, 'n_cycles', (0, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
+    check_param_range(n_cycles, 'n_cycles', (0, np.inf))
 
     amp = amp_by_time(sig, fs, f_range, remove_edges=False, n_cycles=n_cycles)
 

--- a/bycycle/plts/burst.py
+++ b/bycycle/plts/burst.py
@@ -11,7 +11,7 @@ from neurodsp.plts.utils import savefig
 
 from bycycle.plts.cyclepoints import plot_cyclepoints_df
 from bycycle.utils import limit_df, limit_signal, get_extrema_df
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range
 
 ###################################################################################################
 ###################################################################################################
@@ -74,7 +74,7 @@ def plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, xlim=None,
     """
 
     # Ensure arguments are within valid range
-    check_param(fs, 'fs', (0, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
 
     # Normalize signal
     sig = zscore(sig)
@@ -203,7 +203,7 @@ def plot_burst_detect_param(df_features, sig, fs, burst_param, thresh,
     """
 
     # Ensure arguments are within valid range
-    check_param(fs, 'fs', (0, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
 
     # Set default kwargs
     figsize = kwargs.pop('figsize', (15, 3))

--- a/bycycle/plts/burst.py
+++ b/bycycle/plts/burst.py
@@ -87,10 +87,11 @@ def plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, xlim=None,
     _, side_e = get_extrema_df(df_features)
 
     # Remove this kwarg since it isn't stored cycle by cycle in the df (nothing to plot)
-    if 'min_n_cycles' in threshold_kwargs.keys():
-        del threshold_kwargs['min_n_cycles']
+    thresholds = threshold_kwargs.copy()
+    if 'min_n_cycles' in thresholds.keys():
+        del thresholds['min_n_cycles']
 
-    n_kwargs = len(threshold_kwargs.keys())
+    n_kwargs = len(thresholds.keys())
 
     # Create figure and subplots
     if plot_only_result:
@@ -123,7 +124,7 @@ def plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, xlim=None,
     # Plot each burst param
     colors = cycle(['blue', 'red', 'yellow', 'green', 'cyan', 'magenta', 'orange'])
 
-    for idx, osc_key in enumerate(threshold_kwargs.keys()):
+    for idx, osc_key in enumerate(thresholds.keys()):
 
         column = osc_key.replace('_threshold', '')
 
@@ -132,7 +133,7 @@ def plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, xlim=None,
         # Highlight where a burst param falls below threshold
         for _, cyc in df_features.iterrows():
 
-            if cyc[column] < threshold_kwargs[osc_key]:
+            if cyc[column] < thresholds[osc_key]:
                 axes[0].axvspan(times[int(cyc['sample_last_' + side_e])],
                                 times[int(cyc['sample_next_' + side_e])],
                                 alpha=0.5, color=color, lw=0)
@@ -143,7 +144,7 @@ def plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, xlim=None,
             ylabel = column.replace('_', ' ').capitalize()
             xlabel = 'Time (s)' if idx == n_kwargs-1 else ''
 
-            plot_burst_detect_param(df_features, sig, fs, column, threshold_kwargs[osc_key],
+            plot_burst_detect_param(df_features, sig, fs, column, thresholds[osc_key],
                                     figsize=figsize, ax=axes[idx+1], xlim=xlim, xlabel=xlabel,
                                     ylabel=ylabel, color=color, interp=interp)
 

--- a/bycycle/plts/cyclepoints.py
+++ b/bycycle/plts/cyclepoints.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 from neurodsp.plts import plot_time_series
 from neurodsp.plts.utils import savefig
 
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range
 from bycycle.utils import limit_signal, get_extrema_df
 
 ###################################################################################################
@@ -59,7 +59,7 @@ def plot_cyclepoints_df(df_samples, sig, fs, plot_sig=True, plot_extrema=True,
     """
 
     # Ensure arguments are within valid range
-    check_param(fs, 'fs', (0, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
 
     # Determine extrema/zero-crossings from dataframe
     center_e, side_e = get_extrema_df(df_samples)
@@ -131,7 +131,7 @@ def plot_cyclepoints_array(sig, fs, peaks=None, troughs=None, rises=None, decays
     """
 
     # Ensure arguments are within valid range
-    check_param(fs, 'fs', (0, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
 
     # Set times and limits
     times = np.arange(0, len(sig) / fs, 1 / fs)

--- a/bycycle/tests/burst/test_utils.py
+++ b/bycycle/tests/burst/test_utils.py
@@ -60,3 +60,19 @@ def test_recompute_edges(sim_args_comb):
     is_burst_recompute = len(np.where(df_features_edges['is_burst'] == True)[0])
 
     assert is_burst_recompute > is_burst_orig
+
+
+def test_recompute_edge(sim_args_comb):
+
+    # Grab sim arguments from fixture
+    threshold_kwargs = sim_args_comb['threshold_kwargs']
+    df_features = sim_args_comb['df_features']
+
+    threshold_kwargs['amp_consistency_threshold'] = 0
+    threshold_kwargs['period_consistency_threshold'] = 0
+
+    df_features_edge = recompute_edge(df_features.copy(), 0, 'next')
+
+    # The first cycle's consistency will now be a value, rather than nan
+    assert df_features_edge['amp_consistency'][0] != df_features['amp_consistency'][0]
+    assert df_features_edge['period_consistency'][0] != df_features['period_consistency'][0]

--- a/bycycle/utils/__init__.py
+++ b/bycycle/utils/__init__.py
@@ -3,4 +3,4 @@
 from .timeseries import limit_signal
 from .dataframes import (limit_df, get_extrema_df, rename_extrema_df,
                          split_samples_df, drop_samples_df, epoch_df, flatten_dfs)
-from .checks import check_param
+from .checks import check_param_range, check_param_options

--- a/bycycle/utils/checks.py
+++ b/bycycle/utils/checks.py
@@ -1,4 +1,4 @@
 """Checker function."""
 
 # This alias function from NeuroDSP
-from neurodsp.utils.checks import check_param
+from neurodsp.utils.checks import check_param_range, check_param_options

--- a/bycycle/utils/dataframes.py
+++ b/bycycle/utils/dataframes.py
@@ -5,7 +5,7 @@ from itertools import product
 import numpy as np
 import pandas as pd
 
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range
 
 ###################################################################################################
 ###################################################################################################
@@ -47,9 +47,9 @@ def limit_df(df, fs, start=None, stop=None):
     """
 
     # Ensure arguments are within valid range
-    check_param(fs, 'fs', (0, np.inf))
-    check_param(start, 'start', (0, stop))
-    check_param(stop, 'stop', (start, np.inf))
+    check_param_range(fs, 'fs', (0, np.inf))
+    check_param_range(start, 'start', (0, stop))
+    check_param_range(stop, 'stop', (start, np.inf))
 
     center_e, side_e = get_extrema_df(df)
 

--- a/bycycle/utils/timeseries.py
+++ b/bycycle/utils/timeseries.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from bycycle.utils.checks import check_param
+from bycycle.utils.checks import check_param_range
 
 ###################################################################################################
 ###################################################################################################
@@ -40,8 +40,8 @@ def limit_signal(times, sig, start=None, stop=None):
     """
 
     # Ensure arguments are within valid range
-    check_param(start, 'start', (0, stop))
-    check_param(stop, 'stop', (start, np.inf))
+    check_param_range(start, 'start', (0, stop))
+    check_param_range(stop, 'stop', (start, np.inf))
 
     if start is not None:
         sig = sig[times >= start]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy >= 1.18.5
 scipy >=  1.4.1
 pandas >= 0.25.3
 matplotlib >= 3.0.3
-neurodsp >= 2.1.0
+neurodsp @ git+https://github.com/neurodsp-tools/neurodsp.git@main


### PR DESCRIPTION
This is an improvement to #73 and `recompute_edges`. Period/amplitude consistency features may now be computed in one direction for non-bursting cycles that are immediately adjacent to bursts. Before the solution was to drop thresholds for edge cycles which works but was lazier.

```python
import numpy as np
from neurodsp.sim import sim_combined

from bycycle.features import compute_features
from bycycle.burst.utils import recompute_edges
from bycycle.plts import plot_burst_detect_summary

# Simulate
np.random.seed(0)
n_seconds = 10
fs = 1000
f_range = (1, 51)

components = dict(sim_bursty_oscillation=dict(freq=15, cycle='gaussian', std=1),
                  sim_powerlaw=dict(exponent=-2))

sig = sim_combined(n_seconds, fs, components)

times = np.arange(0, len(sig)/fs, 1/fs)

thresholds = {'amp_fraction_threshold': 0.3,
              'amp_consistency_threshold': 0.55,
              'period_consistency_threshold': 0.55,
              'monotonicity_threshold': 0.75,
              'min_n_cycles': 3}

df_features = compute_features(sig, fs, f_range, threshold_kwargs=thresholds)

plot_burst_detect_summary(df_features, sig, fs, thresholds, plot_only_result=True, xlim=(5.8, 6.3))

indices = np.where((df_features['sample_peak'] >= (5.9* fs)) &
                   (df_features['sample_peak'] <= (6.2* fs)))[0]

print('Original:   ', df_features.iloc[indices]['period_consistency'].values)

df_features = recompute_edges(df_features, thresholds)

plot_burst_detect_summary(df_features, sig, fs, thresholds, plot_only_result=True, xlim=(5.8, 6.3))

print('Recomputed: ', df_features.iloc[indices]['period_consistency'].values)
```
![consist](https://user-images.githubusercontent.com/34786005/106841416-edeec180-6656-11eb-872e-e696651fc4b4.png)
