### PR TITLE
[BUG] Fix plot highlighting bug

### DIFF
--- a/bycycle/plts/burst.py
+++ b/bycycle/plts/burst.py
@@ -132,9 +132,10 @@ def plot_burst_detect_summary(df_features, sig, fs, threshold_kwargs, xlim=None,
         # Highlight where a burst param falls below threshold
         for _, cyc in df_features.iterrows():
 
-            if cyc[column] < threshold_kwargs[osc_key]:
-                axes[0].axvspan(times[int(cyc['sample_last_' + side_e])],
-                                times[int(cyc['sample_next_' + side_e])],
+            last_cyc = int(cyc['sample_last_' + side_e])
+            next_cyc = int(cyc['sample_next_' + side_e])
+            if cyc[column] < threshold_kwargs[osc_key] and last_cyc > 0:
+                axes[0].axvspan(times[last_cyc], times[next_cyc],
                                 alpha=0.5, color=color, lw=0)
 
         # Plot each burst param on separate axes

--- a/bycycle/plts/cyclepoints.py
+++ b/bycycle/plts/cyclepoints.py
@@ -70,7 +70,9 @@ def plot_cyclepoints_df(df_samples, sig, fs, plot_sig=True, plot_extrema=True,
 
         peaks = df_samples['sample_' + center_e].values
         troughs = np.append(df_samples['sample_last_' + side_e].values,
-                            df_samples['sample_next_' + side_e].values[-1])
+                            df_samples['sample_next_' + side_e].values)
+        troughs = np.unique(troughs)
+
     if plot_zerox:
 
         rises = df_samples['sample_zerox_rise'].values


### PR DESCRIPTION
This bug occurs when using `compute_features_2d` with `axis=None` (for epoched data). When cycles occur at the edge of epochs, the last trough sample will be negative and highlighting sub-threshold params would be inaccurate.