### PR TITLE
[MRG] Bycycle Class

### DIFF
--- a/bycycle/__init__.py
+++ b/bycycle/__init__.py
@@ -1,3 +1,4 @@
 """ByCycle: cycle-by-cycle analyses of neural oscillations."""
 
 from .version import __version__
+from .objs import Bycycle

--- a/bycycle/__init__.py
+++ b/bycycle/__init__.py
@@ -1,4 +1,4 @@
 """ByCycle: cycle-by-cycle analyses of neural oscillations."""
 
 from .version import __version__
-from .objs import Bycycle
+from .objs import Bycycle, BycycleGroup

--- a/bycycle/objs/__init__.py
+++ b/bycycle/objs/__init__.py
@@ -1,3 +1,3 @@
 """Bycycle class object."""
 
-from .fit import Bycycle
+from .fit import Bycycle, BycycleGroup

--- a/bycycle/objs/__init__.py
+++ b/bycycle/objs/__init__.py
@@ -1,0 +1,3 @@
+"""Bycycle class object."""
+
+from .fit import Bycycle

--- a/bycycle/objs/fit.py
+++ b/bycycle/objs/fit.py
@@ -214,7 +214,7 @@ class BycycleGroup:
 
     def __init__(self, center_extrema='peak', burst_method='cycles', burst_kwargs=None,
                  thresholds=None, find_extrema_kwargs=None, return_samples=True):
-        """Initialize object settings"""
+        """Initialize object settings."""
 
         # Compute features settings
         self.center_extrema = center_extrema
@@ -233,10 +233,8 @@ class BycycleGroup:
         else:
             self.thresholds = thresholds
 
-        if find_extrema_kwargs is None:
-            self.find_extrema_kwargs = {'filter_kwargs': {'n_cycles': 3}}
-        else:
-            self.find_extrema_kwargs = find_extrema_kwargs
+        self.find_extrema_kwargs = {'filter_kwargs': {'n_cycles': 3}} if find_extrema_kwargs \
+            is None else find_extrema_kwargs
 
         self.return_samples = return_samples
 

--- a/bycycle/objs/fit.py
+++ b/bycycle/objs/fit.py
@@ -19,7 +19,7 @@ class Bycycle:
     df_features : pandas.DataFrame
         A dataframe containing shape and burst features for each cycle.
     sig : 1d array
-        Time series.
+        Voltage time series.
     fs : float
         Sampling rate, in Hz.
     f_range : tuple of (float, float)
@@ -57,7 +57,7 @@ class Bycycle:
 
     def __init__(self, center_extrema='peak', burst_method='cycles', burst_kwargs=None,
                  thresholds=None, find_extrema_kwargs=None, return_samples=True):
-        """Initialize object settings"""
+        """Initialize object settings."""
 
         # Compute features settings
         self.center_extrema = center_extrema
@@ -159,7 +159,7 @@ class BycycleGroup:
     dfs_features : list of pandas.DataFrame or list of list of pandas.DataFrame
         Dataframe containing shape and burst features for each cycle.
     sigs : 2d or 3d array
-        Time series.
+        Voltage time series.
     fs : float
         Sampling rate, in Hz.
     f_range : tuple of (float, float)
@@ -243,6 +243,7 @@ class BycycleGroup:
         self.fs = None
         self.f_range = None
         self.axis = None
+        self.n_jobs = None
 
         # Results
         self.dfs_features = []
@@ -311,29 +312,29 @@ class BycycleGroup:
         self.axis = axis
         self.n_jobs = n_jobs
 
-        compute_features_kwargs = dict(
-            center_extrema = self.center_extrema,
-            burst_method = self.burst_method,
-            burst_kwargs = self.burst_kwargs,
-            threshold_kwargs = self.thresholds,
-            find_extrema_kwargs = self.find_extrema_kwargs
-        )
+        compute_features_kwargs = {
+            'center_extrema': self.center_extrema,
+            'burst_method': self.burst_method,
+            'burst_kwargs': self.burst_kwargs,
+            'threshold_kwargs': self.thresholds,
+            'find_extrema_kwargs': self.find_extrema_kwargs
+        }
 
-        compute_func = compute_features_2d if sigs.ndim == 2 else compute_features_3d
+        compute_func = compute_features_2d if self.sigs.ndim == 2 else compute_features_3d
 
         features = compute_func(self.sigs, self.fs, self.f_range, compute_features_kwargs,
-                                self.axis, self.return_samples, n_jobs, progress)
+                                self.axis, self.return_samples, self.n_jobs, progress)
 
         # Initialize lists
-        if sigs.ndim == 3:
+        if  self.sigs.ndim == 3:
             self.dfs_features = np.zeros((len(features), len(features[0]))).tolist()
         else:
             self.dfs_features = np.zeros(len(features)).tolist()
 
         # Convert dataframes to Bycycle objects
-        for dim0, sig in enumerate(sigs):
+        for dim0, sig in enumerate(self.sigs):
 
-            if sigs.ndim == 3:
+            if self.sigs.ndim == 3:
 
                 for dim1, sig_ in enumerate(sig):
 

--- a/bycycle/objs/fit.py
+++ b/bycycle/objs/fit.py
@@ -1,0 +1,168 @@
+"""Bycycle class object."""
+
+from bycycle.features import compute_features
+from bycycle.plts import plot_burst_detect_summary
+
+from neurodsp.plts.utils import savefig
+
+###################################################################################################
+###################################################################################################
+
+class Bycycle:
+    """Compute bycycle features from a signal.
+
+    Attributes
+    ----------
+    sig : 1d array
+        Time series.
+    fs : float
+        Sampling rate, in Hz.
+    f_range : tuple of (float, float)
+        Frequency range for narrowband signal of interest (Hz).
+    center_extrema : {'peak', 'trough'}
+        The center extrema in the cycle.
+
+        - 'peak' : cycles are defined trough-to-trough
+        - 'trough' : cycles are defined peak-to-peak
+
+    burst_method : {'cycles', 'amp'}
+        Method for detecting bursts.
+
+        - 'cycles': detect bursts based on the consistency of consecutive periods & amplitudes
+        - 'amp': detect bursts using an amplitude threshold
+
+    burst_kwargs : dict, optional, default: None
+        Additional keyword arguments defined in :func:`~.compute_burst_fraction` for dual
+        amplitude threshold burst detection (i.e. when burst_method='amp').
+    threshold_kwargs : dict, optional, default: None
+        Feature thresholds for cycles to be considered bursts, matching keyword arguments for:
+
+        - :func:`~.detect_bursts_cycles` for consistency burst detection
+          (i.e. when burst_method='cycles')
+        - :func:`~.detect_bursts_amp` for  amplitude threshold burst detection
+          (i.e. when burst_method='amp').
+
+    find_extrema_kwargs : dict, optional, default: None
+        Keyword arguments for function to find peaks an troughs (:func:`~.find_extrema`)
+        to change filter parameters or boundary. By default, the filter length is set to three
+        cycles of the low cutoff frequency (``f_range[0]``).
+    return_samples : bool, optional, default: True
+        Returns samples indices of cyclepoints used for determining features if True.
+    df_features : pandas.DataFrame
+        A dataframe containing shape and burst features for each cycle.
+    """
+
+    def __init__(self):
+        """Initialize object settings"""
+
+        self.center_extrema = 'peak'
+
+        self.burst_method = 'cycles'
+        self.burst_kwargs = None
+
+        self.thresholds = {
+            'amp_fraction_threshold': 0.,
+            'amp_consistency_threshold': .5,
+            'period_consistency_threshold': .5,
+            'monotonicity_threshold': .8,
+            'min_n_cycles': 3
+        }
+
+        self.find_extrema_kwargs = None
+        self.return_samples = True
+
+        self.df_features = None
+        self.sig = None
+        self.fs = None
+        self.f_range = None
+
+
+    def fit(self, sig, fs, f_range, center_extrema=None, burst_method=None,
+            burst_kwargs=None, thresholds=None, find_extrema_kwargs=None, return_samples=None):
+        """Run the bycycle algorithm on a signal.
+
+        Parameters
+        ----------
+        sig : 1d array
+            Time series.
+        fs : float
+            Sampling rate, in Hz.
+        f_range : tuple of (float, float)
+            Frequency range for narrowband signal of interest (Hz).
+        center_extrema : {'peak', 'trough'}
+            The center extrema in the cycle.
+
+            - 'peak' : cycles are defined trough-to-trough
+            - 'trough' : cycles are defined peak-to-peak
+
+        burst_method : {'cycles', 'amp'}
+            Method for detecting bursts.
+
+            - 'cycles': detect bursts based on the consistency of consecutive periods & amplitudes
+            - 'amp': detect bursts using an amplitude threshold
+
+        burst_kwargs : dict, optional, default: None
+            Additional keyword arguments defined in :func:`~.compute_burst_fraction` for dual
+            amplitude threshold burst detection (i.e. when burst_method='amp').
+        threshold_kwargs : dict, optional, default: None
+            Feature thresholds for cycles to be considered bursts, matching keyword arguments for:
+
+            - :func:`~.detect_bursts_cycles` for consistency burst detection
+            (i.e. when burst_method='cycles')
+            - :func:`~.detect_bursts_amp` for  amplitude threshold burst detection
+            (i.e. when burst_method='amp').
+
+        find_extrema_kwargs : dict, optional, default: None
+            Keyword arguments for function to find peaks an troughs (:func:`~.find_extrema`)
+            to change filter parameters or boundary. By default, the filter length is set to three
+            cycles of the low cutoff frequency (``f_range[0]``).
+        return_samples : bool, optional, default: True
+            Returns samples indices of cyclepoints used for determining features if True.
+        """
+
+        # Add settings as attributes
+        self.sig = sig
+        self.fs = fs
+        self.f_range = f_range
+
+        self.center_extrema = center_extrema if center_extrema is not None else self.center_extrema
+
+        self.burst_method = burst_method if burst_method is not None else self.burst_method
+
+        self.burst_kwargs = {} if burst_kwargs is None else self.burst_kwargs
+
+        self.thresholds = thresholds if thresholds is not None else self.thresholds
+
+        self.find_extrema_kwargs = {'filter_kwargs': {'n_cycles': 3}} if find_extrema_kwargs \
+            is None else self.find_extrema_kwargs
+
+        self.return_samples = return_samples
+
+        df_features = compute_features(self.sig, self.fs, self.f_range, self.center_extrema,
+                                       self.burst_method, self.burst_kwargs, self.thresholds,
+                                       self.find_extrema_kwargs, self.return_samples)
+
+        self.df_features = df_features
+
+
+    @savefig
+    def plot(self, xlim=None, figsize=(15, 3), plot_only_results=False, interp=True):
+        """Plot burst detection results.
+
+        Parameters
+        ----------
+        xlim : tuple of (float, float), optional, default: None
+            Start and stop times for plot.
+        figsize : tuple of (float, float), optional, default: (15, 3)
+            Size of each plot.
+        plot_only_result : bool, optional, default: False
+            Plot only the signal and bursts, excluding burst parameter plots.
+        interp : bool, optional, default: True
+            If True, interpolates between given values. Otherwise, plots in a step-wise fashion.
+        """
+
+        if self.df_features is None or self.sig is None or self.fs is None:
+            raise ValueError('The fit method must be successfully called prior to plotting.')
+
+        plot_burst_detect_summary(self.df_features, self.sig, self.fs, self.thresholds,
+                                  xlim, figsize, plot_only_results, interp)

--- a/bycycle/tests/objs/test_fit.py
+++ b/bycycle/tests/objs/test_fit.py
@@ -1,0 +1,58 @@
+"""Test functions for the Bycycle class."""
+
+from pytest import raises
+
+import pandas as pd
+
+from bycycle import Bycycle
+from bycycle.tests.tutils import plot_test
+
+###################################################################################################
+###################################################################################################
+
+def test_bycycle():
+    """Test initializing a Bycycle object."""
+
+    bm = Bycycle()
+
+    assert bm.center_extrema == 'peak'
+    assert bm.burst_method == 'cycles'
+    assert isinstance(bm.thresholds, dict)
+    assert bm.return_samples
+
+    defaults = [bm.burst_kwargs, bm.find_extrema_kwargs, bm.df_features, bm.sig, bm.fs, bm.f_range]
+    assert defaults == [None] * len(defaults)
+
+
+def test_bycycle_fit(sim_args):
+    """Test the fit method of a Bycycle object."""
+
+    bm = Bycycle()
+
+    sig = sim_args['sig']
+    fs = sim_args['fs']
+    f_range = sim_args['f_range']
+
+    bm.fit(sig, fs, f_range)
+
+    assert isinstance(bm.df_features, pd.DataFrame)
+    assert bm.fs == fs
+    assert bm.f_range == f_range
+    assert (bm.sig == sig).all()
+
+
+@plot_test
+def test_bycycle_plot(sim_args):
+    """Test the plot method of a Bycycle object."""
+
+    bm = Bycycle()
+
+    sig = sim_args['sig']
+    fs = sim_args['fs']
+    f_range = sim_args['f_range']
+
+    with raises(ValueError):
+        bm.plot()
+
+    bm.fit(sig, fs, f_range)
+    bm.plot()

--- a/bycycle/tests/objs/test_fit.py
+++ b/bycycle/tests/objs/test_fit.py
@@ -1,10 +1,13 @@
 """Test functions for the Bycycle class."""
 
+from inspect import ismethod
+
 from pytest import raises
 
 import pandas as pd
+import numpy as np
 
-from bycycle import Bycycle
+from bycycle import Bycycle, BycycleGroup
 from bycycle.tests.tutils import plot_test
 
 ###################################################################################################
@@ -18,9 +21,11 @@ def test_bycycle():
     assert bm.center_extrema == 'peak'
     assert bm.burst_method == 'cycles'
     assert isinstance(bm.thresholds, dict)
+    assert isinstance(bm.find_extrema_kwargs, dict)
+    assert bm.burst_kwargs == {}
     assert bm.return_samples
 
-    defaults = [bm.burst_kwargs, bm.find_extrema_kwargs, bm.df_features, bm.sig, bm.fs, bm.f_range]
+    defaults = [bm.df_features, bm.sig, bm.fs, bm.f_range]
     assert defaults == [None] * len(defaults)
 
 
@@ -32,6 +37,9 @@ def test_bycycle_fit(sim_args):
     sig = sim_args['sig']
     fs = sim_args['fs']
     f_range = sim_args['f_range']
+
+    with raises(ValueError):
+        bm.fit(np.array([sig, sig]), fs, f_range)
 
     bm.fit(sig, fs, f_range)
 
@@ -56,3 +64,75 @@ def test_bycycle_plot(sim_args):
 
     bm.fit(sig, fs, f_range)
     bm.plot()
+
+
+def test_bycyclegroup():
+    """Test initializing a BycycleGroup object."""
+
+    bg = BycycleGroup()
+
+    assert isinstance(bg.dfs_features, list) and len(bg.dfs_features) == 0
+    assert bg.center_extrema == 'peak'
+    assert bg.burst_method == 'cycles'
+    assert isinstance(bg.thresholds, dict)
+    assert isinstance(bg.find_extrema_kwargs, dict)
+    assert bg.burst_kwargs == {}
+    assert bg.return_samples
+
+    defaults = [bg.sigs, bg.fs, bg.f_range]
+    assert defaults == [None] * len(defaults)
+
+
+def test_bycyclegroup_fit(sim_args):
+    """Test the fit method of a BycycleGroup object."""
+
+    # 2d case
+    sigs = np.array([sim_args['sig']] * 2)
+    fs = sim_args['fs']
+    f_range = sim_args['f_range']
+    thresholds = {
+        'amp_fraction_threshold': 0.,
+        'amp_consistency_threshold': .5,
+        'period_consistency_threshold': .5,
+        'monotonicity_threshold': .8,
+        'min_n_cycles': 3
+    }
+
+    bg = BycycleGroup(thresholds=thresholds)
+
+    with raises(ValueError):
+        bg.fit(sigs[0], fs, f_range)
+
+    bg.fit(sigs, fs, f_range)
+
+    assert isinstance(bg.dfs_features, list)
+    for bm in bg:
+        assert isinstance(bm, Bycycle)
+    assert isinstance(bg.dfs_features[0].df_features, pd.DataFrame)
+    assert ismethod(bg.dfs_features[0].fit)
+    assert ismethod(bg.dfs_features[0].plot)
+    assert len(bg) == 2
+    assert bg.fs == fs
+    assert bg.f_range == f_range
+    assert (bg.sigs == sigs).all()
+
+    # 3d case
+    sigs = np.array([sigs, sigs])
+    bg = BycycleGroup()
+
+    with raises(ValueError):
+        bg.fit(sigs[0][0], fs, f_range)
+
+    bg.fit(sigs, fs, f_range)
+
+    assert isinstance(bg.dfs_features, list)
+    assert isinstance(bg.dfs_features[0], list)
+    assert isinstance(bg.dfs_features[0][0], Bycycle)
+    assert isinstance(bg.dfs_features[0][0].df_features, pd.DataFrame)
+    assert ismethod(bg.dfs_features[0][0].fit)
+    assert ismethod(bg.dfs_features[0][0].plot)
+    assert len(bg) == 2
+    assert len(bg[0]) == 2
+    assert bg.fs == fs
+    assert bg.f_range == f_range
+    assert (bg.sigs == sigs).all()


### PR DESCRIPTION
This adds a simple bycycle class to keep track of various settings as attributes. The motivation for this was having to look up the default `threshold_kwargs` (needed for plotting) regularly. The conventions here follow napp. I need to add an equivalent 2d arrays.

```python
from bycycle import Bycycle
from neurodsp.sim import sim_oscillation

# Simulate
fs = 1000
sig = sim_oscillation(10, fs, 10)

bm = Bycycle()
bm.fit(sig, fs, (1, 100))

# Access dataframe
bm.df_features

# Access threholds
bm.thresholds

bm.plot()
```