### PR TITLE
[ENH] Period and amplitude consistency mode

### DIFF
--- a/bycycle/features/features.py
+++ b/bycycle/features/features.py
@@ -15,7 +15,7 @@ from bycycle.burst import detect_bursts_cycles, detect_bursts_amp
 
 def compute_features(sig, fs, f_range, center_extrema='peak', burst_method='cycles',
                      burst_kwargs=None, threshold_kwargs=None, find_extrema_kwargs=None,
-                     return_samples=True):
+                     consistency_mode='min', return_samples=True):
     """Compute shape and burst features for each cycle.
 
     Parameters
@@ -53,6 +53,8 @@ def compute_features(sig, fs, f_range, center_extrema='peak', burst_method='cycl
         Keyword arguments for function to find peaks an troughs (:func:`~.find_extrema`)
         to change filter parameters or boundary. By default, the filter length is set to three
         cycles of the low cutoff frequency (``f_range[0]``).
+    consistency_mode : {'min', 'mean', 'max'}
+        Adjacent amplitude and period comparison method.
     return_samples : bool, optional, default: True
         Returns samples indices of cyclepoints used for determining features if True.
 
@@ -133,7 +135,8 @@ def compute_features(sig, fs, f_range, center_extrema='peak', burst_method='cycl
 
     # Compute burst features for each cycle
     df_burst_features = compute_burst_features(df_shape_features, sig, burst_method=burst_method,
-                                               burst_kwargs=burst_kwargs)
+                                               burst_kwargs=burst_kwargs,
+                                               consistency_mode=consistency_mode)
 
     # Concatenate shape and burst features
     df_features = pd.concat((df_burst_features, df_shape_features), axis=1)

--- a/bycycle/objs/fit.py
+++ b/bycycle/objs/fit.py
@@ -51,12 +51,15 @@ class Bycycle:
         Keyword arguments for function to find peaks an troughs (:func:`~.find_extrema`)
         to change filter parameters or boundary. By default, the filter length is set to three
         cycles of the low cutoff frequency (``f_range[0]``).
+    consistency_mode : {'min', 'mean', 'max'}
+        Adjacent amplitude and period comparison method.
     return_samples : bool, optional, default: True
         Returns samples indices of cyclepoints used for determining features if True.
     """
 
     def __init__(self, center_extrema='peak', burst_method='cycles', burst_kwargs=None,
-                 thresholds=None, find_extrema_kwargs=None, return_samples=True):
+                 thresholds=None, find_extrema_kwargs=None, consistency_mode='min',
+                 return_samples=True):
         """Initialize object settings."""
 
         # Compute features settings
@@ -81,6 +84,7 @@ class Bycycle:
         else:
             self.find_extrema_kwargs = find_extrema_kwargs
 
+        self.consistency_mode = consistency_mode
         self.return_samples = return_samples
 
         # Compute features args
@@ -115,7 +119,8 @@ class Bycycle:
 
         self.df_features = compute_features(self.sig, self.fs, self.f_range, self.center_extrema,
                                             self.burst_method, self.burst_kwargs, self.thresholds,
-                                            self.find_extrema_kwargs, self.return_samples)
+                                            self.find_extrema_kwargs, self.consistency_mode,
+                                            self.return_samples)
 
 
     @savefig
@@ -208,12 +213,15 @@ class BycycleGroup:
         - ``axis=(0, 1)`` : Iterates over 1D slices along the zeroth and first dimensions (i.e
         across each signal independently in (n_participants, n_channels, n_timepoints)).
 
+    consistency_mode : {'min', 'mean', 'max'}
+        Adjacent amplitude and period comparison method.
     return_samples : bool, optional, default: True
         Returns samples indices of cyclepoints used for determining features if True.
     """
 
     def __init__(self, center_extrema='peak', burst_method='cycles', burst_kwargs=None,
-                 thresholds=None, find_extrema_kwargs=None, return_samples=True):
+                 thresholds=None, find_extrema_kwargs=None, consistency_mode='min',
+                 return_samples=True):
         """Initialize object settings."""
 
         # Compute features settings
@@ -236,6 +244,7 @@ class BycycleGroup:
         self.find_extrema_kwargs = {'filter_kwargs': {'n_cycles': 3}} if find_extrema_kwargs \
             is None else find_extrema_kwargs
 
+        self.consistency_mode = consistency_mode
         self.return_samples = return_samples
 
         # Compute features args
@@ -317,7 +326,8 @@ class BycycleGroup:
             'burst_method': self.burst_method,
             'burst_kwargs': self.burst_kwargs,
             'threshold_kwargs': self.thresholds,
-            'find_extrema_kwargs': self.find_extrema_kwargs
+            'find_extrema_kwargs': self.find_extrema_kwargs,
+            'consistency_mode': self.consistency_mode
         }
 
         compute_func = compute_features_2d if self.sigs.ndim == 2 else compute_features_3d

--- a/bycycle/tests/features/test_burst.py
+++ b/bycycle/tests/features/test_burst.py
@@ -4,7 +4,7 @@ import pytest
 
 import numpy as np
 
-from bycycle.features import *
+from bycycle.features.burst import *
 
 ###################################################################################################
 ###################################################################################################
@@ -38,8 +38,16 @@ def test_compute_burst_features(sim_args, dual_thresh, center_e):
         burst_fraction = df_burst_features['burst_fraction']
 
         assert np.nan not in burst_fraction
-
         assert np.all((burst_fraction >= 0) & (burst_fraction <= 1))
+
+        # Excpeted error
+        try:
+            df_burst_features = compute_burst_features(df_shape_features, sig, burst_method='amp',
+                                                       burst_kwargs={})
+            assert False
+        except ValueError as e:
+            pass
+
 
     else:
 
@@ -57,3 +65,37 @@ def test_compute_burst_features(sim_args, dual_thresh, center_e):
         assert np.all((monotonicity >= 0) & (monotonicity <= 1))
 
     assert len(df_shape_features) == len(df_burst_features)
+
+    # Expected error
+    try:
+        df_burst_features = compute_burst_features(df_shape_features, sig, burst_method=None)
+        assert False
+    except ValueError as e:
+        pass
+
+
+@pytest.mark.parametrize("direction", ['both', 'next', 'last'])
+def test_compute_amp_consistency(sim_args, direction):
+
+    df_shape_features = sim_args['df_shapes']
+    df_burst = sim_args['df_burst']
+    print(df_burst['amp_consistency'])
+    amp_consist_min = compute_amp_consistency(df_shape_features, direction, 'min')
+    amp_consist_mean = compute_amp_consistency(df_shape_features, direction, 'mean')
+    amp_consist_max = compute_amp_consistency(df_shape_features, direction, 'max')
+
+    assert amp_consist_min[1:-1].mean() <= amp_consist_mean[1:-1].mean() \
+        <= amp_consist_max[1:-1].mean()
+
+
+@pytest.mark.parametrize("direction", ['both', 'next', 'last'])
+def test_compute_period_consistency(sim_args, direction):
+
+    df_shape_features = sim_args['df_shapes']
+
+    period_consist_min = compute_period_consistency(df_shape_features, direction, 'min')
+    period_consist_mean = compute_period_consistency(df_shape_features, direction, 'mean')
+    period_consist_max = compute_period_consistency(df_shape_features, direction, 'max')
+
+    assert period_consist_min[1:-1].mean() <= period_consist_mean[1:-1].mean() \
+        <= period_consist_max[1:-1].mean()

--- a/bycycle/tests/objs/test_fit.py
+++ b/bycycle/tests/objs/test_fit.py
@@ -24,6 +24,7 @@ def test_bycycle():
     assert isinstance(bm.find_extrema_kwargs, dict)
     assert bm.burst_kwargs == {}
     assert bm.return_samples
+    assert bm.consistency_mode == 'min'
 
     defaults = [bm.df_features, bm.sig, bm.fs, bm.f_range]
     assert defaults == [None] * len(defaults)
@@ -78,6 +79,7 @@ def test_bycyclegroup():
     assert isinstance(bg.find_extrema_kwargs, dict)
     assert bg.burst_kwargs == {}
     assert bg.return_samples
+    assert bg.consistency_mode == 'min'
 
     defaults = [bg.sigs, bg.fs, bg.f_range]
     assert defaults == [None] * len(defaults)


### PR DESCRIPTION
This adds an optional parameter (`consistency_mode`) to change how consistency measures are determined. Previously, amplitude consistency was computed as `np.min([consist_current, consist_next, consist_last])`. The first cycle of a burst would always have a small consist_last (the last cycle would always have a small consist_next), results in potentially mislabeled first/last cycles per each burst.

A solution was merged in #90, which allowed lowering the consistency thresholds for the edges of bursts. This PR offers an alternative, which allows taking the mean or max of adjacent periods/amplitudes, in addition to the min.

I'd argue that setting consistency_mode == 'mean', is a better default in some cases. One potential downside of using mean consistency, however, is that the consistency of non-burst cycles next to bursts will be a inflated. I have left the default to the original 'min' for now.