### PR TITLE
[BUG] Invert spike fit params

### DIFF
--- a/bycycle/spikes/features/gaussians.py
+++ b/bycycle/spikes/features/gaussians.py
@@ -74,6 +74,9 @@ def _compute_gaussian_features(index, df_samples=None, sig=None,
     sig_cyc = sig[start:end+1]
     times_cyc = np.arange(0, len(sig_cyc)/fs, 1/fs)
 
+    # Demean
+    sig_cyc = sig_cyc - sig_cyc.mean()
+
     # Initial parameter estimation
     _params = estimate_params(df_samples.iloc[index], sig_cyc, fs, n_gaussians)
 

--- a/bycycle/spikes/objs.py
+++ b/bycycle/spikes/objs.py
@@ -174,6 +174,14 @@ class Spikes:
 
             self._param_labels = param_labels
 
+            # Invert parameters
+            if self.center_extrema == 'peak':
+
+                invert_inds = [9, 10, 11, 12] if len(params[0][:-3]) % 3 == 0 else [6, 7, 10]
+
+                for ind in invert_inds:
+                    self.params[:, ind] = self.params[:, ind] * -1
+
             param_dict = {k: v for k, v in zip(param_labels, self.params.transpose())}
             df_gaussian_features = pd.DataFrame.from_dict(param_dict)
 

--- a/bycycle/spikes/utils.py
+++ b/bycycle/spikes/utils.py
@@ -92,10 +92,13 @@ def split_signal(df_samples, sig, demean=True):
 
         sig_cyc = sig[start:end]
 
+        # Demean
+        sig_cyc = sig_cyc - sig_cyc.mean() if demean else sig_cyc
+
         if pad_right != 0:
-            spikes[idx][pad_left:-pad_right] = sig_cyc - sig_cyc.mean()
+            spikes[idx][pad_left:-pad_right] = sig_cyc
         else:
-            spikes[idx][pad_left:] = sig_cyc - sig_cyc.mean()
+            spikes[idx][pad_left:] = sig_cyc
 
     return spikes
 

--- a/bycycle/spikes/utils.py
+++ b/bycycle/spikes/utils.py
@@ -51,7 +51,7 @@ def create_cyclepoints_df(sig, starts, decays, troughs, rises, last_peaks, next_
     return df_samples
 
 
-def split_signal(df_samples, sig):
+def split_signal(df_samples, sig, demean=True):
     """Split a signal into segmented spikes.
 
     Parameters
@@ -60,6 +60,8 @@ def split_signal(df_samples, sig):
         Cyclepoint locaions, in samples. Returned from func:`~.create_cyclepoints_df`.
     sig : 1d array
         Voltage time series.
+    demean : bool, optional, default: True
+        Demeans each cycle individually.
 
     Returns
     -------
@@ -88,10 +90,12 @@ def split_signal(df_samples, sig):
         pad_left = max_left - (trough - start)
         pad_right = max_right - (end - trough)
 
+        sig_cyc = sig[start:end]
+
         if pad_right != 0:
-            spikes[idx][pad_left:-pad_right] = sig[start:end]
+            spikes[idx][pad_left:-pad_right] = sig_cyc - sig_cyc.mean()
         else:
-            spikes[idx][pad_left:] = sig[start:end]
+            spikes[idx][pad_left:] = sig_cyc - sig_cyc.mean()
 
     return spikes
 


### PR DESCRIPTION
This inverts the heights and alpha sign when fitting peak centered spikes. The signal is inverted and then gaussians the same as for trough-centered spikes. The resulting parameters are then inverted to reflect this.

This also adds demeaning for each spike separately, to adjust the baseline of simulated gaussians.