### PR TITLE
[WIP] Citation cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,17 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Cole"
+  given-names: "Scott"
+- family-names: "Voytek"
+  given-names: "Bradley"
+title: "Cycle-by-cycle analysis of neural oscillations"
+version: 1.0.0
+doi: 10.1152/JN.00273.2019
+date-released: 2019-01-01
+url: "https://github.com/bycycle-tools/bycycle"
+journal: "Journal of Neurophysiology"
+volume: 12
+issue: 2
+start: 849
+end: 861


### PR DESCRIPTION
This adds a cff file that gets added to the sidebar. The citation file requires this specific format to work, and doesn't display all of of the fields correctly (journal, issue, pages). The cff file creates a sidebar dropdown with two copy options.

APA: 
```
Cole S., Voytek B. (2019). Cycle-by-cycle analysis of neural oscillations (version 1.0.0). DOI: https://doi.org/10.1152/JN.00273.2019
```

BibTeX:
```
@misc{Cole_Cyclebycycle_analysis_of_2019,
author = {Cole, Scott and Voytek, Bradley},
doi = {10.1152/JN.00273.2019},
month = {1},
title = {Cycle-by-cycle analysis of neural oscillations},
url = {https://github.com/bycycle-tools/bycycle},
year = {2019}
}
```

We may want to wait until github sorts out this extension since the rendered citations are incomplete, despite providing the required info. Ideally, they should support standard formats other than cff.