### PR TITLE
[ENH] Add min_burst_duration

### DIFF
--- a/bycycle/features/burst.py
+++ b/bycycle/features/burst.py
@@ -32,6 +32,7 @@ def compute_burst_features(df_shape_features, sig, burst_method='cycles', burst_
         - ``f_range`` : required for dual amplitude threshold burst detection
         - ``amp_threshes`` : optional, default: (1, 2)
         - ``min_n_cycles`` : optional, default: 3
+        - ``min_burst_duration`` : optional, default: None
         - ``filter_kwargs`` : optional, default: None
 
     Returns
@@ -304,7 +305,7 @@ def compute_monotonicity(df_samples, sig):
 
 
 def compute_burst_fraction(df_samples, sig, fs, f_range, amp_threshes=(1, 2),
-                           min_n_cycles=3, filter_kwargs=None):
+                           min_n_cycles=3, min_burst_duration=None, filter_kwargs=None):
     """Compute the proportion of each cycle that is bursting using a dual threshold algorithm.
 
     Parameters
@@ -323,6 +324,8 @@ def compute_burst_fraction(df_samples, sig, fs, f_range, amp_threshes=(1, 2),
         the median amplitude (value 1).
     min_n_cycles : int, optional, default: 3
         Minimum number of consecutive cycles to be identified as an oscillation.
+    min_burst_duration : float, optional, default: None
+        Minimum length of a burst, in seconds.
     filter_kwargs : dict, optional, default: None
         Keyword arguments to :func:`~neurodsp.filt.filter.filter_signal`.
 
@@ -356,8 +359,13 @@ def compute_burst_fraction(df_samples, sig, fs, f_range, amp_threshes=(1, 2),
     filter_kwargs = {} if filter_kwargs is None else filter_kwargs
 
     # Detect bursts using the dual amplitude threshold approach
-    is_burst = detect_bursts_dual_threshold(sig, fs, amp_threshes, f_range,
-                                            min_n_cycles=min_n_cycles, **filter_kwargs)
+    if min_burst_duration is not None:
+        min_n_cycles = None
+
+    is_burst = detect_bursts_dual_threshold(
+        sig, fs, amp_threshes, f_range, min_n_cycles=min_n_cycles,
+        min_burst_duration=min_burst_duration, **filter_kwargs
+    )
 
     # Convert the boolean array to binary
     is_burst = is_burst.astype(int)

--- a/bycycle/features/features.py
+++ b/bycycle/features/features.py
@@ -131,6 +131,11 @@ def compute_features(sig, fs, f_range, center_extrema='peak', burst_method='cycl
         burst_kwargs['fs'] = fs
         burst_kwargs['f_range'] = f_range
 
+    if burst_method == 'amp' and 'min_n_cycles' not in burst_kwargs.keys():
+        burst_kwargs['min_n_cycles'] = threshold_kwargs.copy().pop('min_n_cycles', 3)
+    elif burst_method == 'amp' and 'min_n_cycles' in burst_kwargs.keys():
+        threshold_kwargs['min_n_cycles'] = burst_kwargs['min_n_cycles']
+
     # Compute burst features for each cycle
     df_burst_features = compute_burst_features(df_shape_features, sig, burst_method=burst_method,
                                                burst_kwargs=burst_kwargs)


### PR DESCRIPTION
This adds min_burst_duration as an optional input to the neurodsp's `detect_bursts_dual_threshold`. Note, this only affects the `is_burst` sample-by-sample array. `min_n_cycles` is still used for the cycle-by-cycle basis of burst detection.

@apoorva6262 let me know if this works for you or not. Note that, `min_n_cycles` should be passed to `thresold_kwargs`, as these threshold are all applied on a cycle-by-cycle basis, whereas `min_burst_duration` should be passed to `burst_kwargs` since it's a unique kwarg for `burst_method == 'amp'`.

```python
import numpy as np
from neurodsp.sim import sim_bursty_oscillation
from neurodsp.burst import detect_bursts_dual_threshold
from neurodsp.plts import plot_bursts

from bycycle.features import compute_features
from bycycle.plts import plot_burst_detect_summary

np.random.seed(0)

n_seconds = 10
fs = 1000
f_range = (1, 100)

sig = sim_bursty_oscillation(n_seconds, fs, freq=20, phase='min')

burst_kwargs = {'amp_threshes': (.5, 1), 'min_burst_duration': .01}

threshold_kwargs = {'burst_fraction_threshold': .5, 'min_n_cycles': 1}

df = compute_features(sig, fs, f_range, burst_method='amp', burst_kwargs=burst_kwargs,
                      threshold_kwargs=threshold_kwargs)

plot_burst_detect_summary(df, sig, fs, threshold_kwargs=threshold_kwargs)
```