### PR TITLE
[WIP] optimize trough cyclepoints

### DIFF
--- a/bycycle/cyclepoints/extrema.py
+++ b/bycycle/cyclepoints/extrema.py
@@ -1,6 +1,7 @@
 """Find extrema for individual cycles."""
 
 import numpy as np
+from scipy.signal import resample
 
 from neurodsp.filt import filter_signal
 from neurodsp.filt.fir import compute_filter_length
@@ -12,7 +13,7 @@ from bycycle.cyclepoints.zerox import find_flank_zerox
 ###################################################################################################
 
 def find_extrema(sig, fs, f_range, boundary=0, first_extrema='peak',
-                 filter_kwargs=None, pass_type='bandpass', pad=True):
+                 filter_kwargs=None, pass_type='bandpass', pad=True, optimize=None):
     """Identify peaks and troughs in a time series.
 
     Parameters
@@ -36,6 +37,9 @@ def find_extrema(sig, fs, f_range, boundary=0, first_extrema='peak',
         Which kind of filter pass_type is consistent with the frequency definition provided.
     pad : bool, optional, default: True
         Whether to pad ``sig`` with zeros to prevent missed cyclepoints at the edges.
+    optimize : tuple of (int, float), optional, default: None
+        An integer defining a set sample spacing between correlated cycles and a float that defines
+        the correlation threshold to sub-select cycles.
 
     Returns
     -------
@@ -78,10 +82,10 @@ def find_extrema(sig, fs, f_range, boundary=0, first_extrema='peak',
                                          n_cycles=filter_kwargs.get('n_cycles', 3))
 
         # Pad the signal
-        sig = np.pad(sig, int(np.ceil(filt_len/2)), mode='constant')
+        sig_pad = np.pad(sig, int(np.ceil(filt_len/2)), mode='constant')
 
     # Narrowband filter signal
-    sig_filt = filter_signal(sig, fs, pass_type, f_range, remove_edges=False, **filter_kwargs)
+    sig_filt = filter_signal(sig_pad, fs, pass_type, f_range, remove_edges=False, **filter_kwargs)
 
     # Find rising and decaying zero-crossings (narrowband)
     rise_xs = find_flank_zerox(sig_filt, 'rise')
@@ -111,7 +115,7 @@ def find_extrema(sig, fs, f_range, boundary=0, first_extrema='peak',
         next_decay = _decay_xs[0]
 
         # Identify time of peak
-        peaks[p_idx] = np.argmax(sig[last_rise:next_decay]) + last_rise
+        peaks[p_idx] = np.argmax(sig_pad[last_rise:next_decay]) + last_rise
 
     # Calculate trough samples
     troughs = np.zeros(n_troughs, dtype=int)
@@ -129,7 +133,7 @@ def find_extrema(sig, fs, f_range, boundary=0, first_extrema='peak',
         next_rise = _rise_xs[0]
 
         # Identify time of trough
-        troughs[t_idx] = np.argmin(sig[last_decay:next_rise]) + last_decay
+        troughs[t_idx] = np.argmin(sig_pad[last_decay:next_rise]) + last_decay
 
     # Remove padding
     peaks = peaks - int(np.ceil(filt_len/2))
@@ -151,4 +155,91 @@ def find_extrema(sig, fs, f_range, boundary=0, first_extrema='peak',
     else:
         raise ValueError('Parameter "first_extrema" is invalid')
 
+    if optimize is not None:
+        troughs = optimize_troughs(sig, peaks, troughs, optimize[0], optimize[1])
+
     return peaks, troughs
+
+
+
+def optimize_troughs(sig, peaks, troughs, cyc_len, corr_thresh=.75):
+    """Optimized troughs based on a pre-determined cycle length.
+
+    Parameters
+    ----------
+    sig : 1d array
+        Voltage time series.
+    cyc_len : int
+        Length to fix each cycle to.
+    corr_thresh : float, optional, default: 0.75
+        Correlation threshold to refine cycle definitions.
+
+    Returns
+    -------
+    troughs_fixed : 1d array
+        Sample of throughs, fixed at the pre-determined length.
+    """
+
+    # Resample to target cycle length for comparison
+    sig_resample = np.zeros((len(troughs)-1, cyc_len))
+
+    for tind, trough in enumerate(troughs[:-1]):
+        _sig = sig[trough:troughs[tind+1]].copy()
+        _sig -= _sig.mean()
+        sig_resample[tind] = resample(_sig, cyc_len)
+
+    sig_avg = sig_resample.mean(axis=0)
+
+    # Find correlated cycles
+    mask = np.zeros(len(troughs), dtype=bool)
+
+    for ind, _sig in enumerate(sig_resample):
+        if np.corrcoef(sig_avg, _sig)[0][1] > corr_thresh:
+            mask[ind] = True
+
+    starts = np.where(mask)[0]
+    inds = np.unique(np.append(starts, starts+1))
+
+    # Evenly space troughs by cyc_len
+    troughs_fixed = troughs[starts].copy()
+
+    for ind, start in enumerate(starts):
+        if ind < len(starts) - 1 and starts[ind+1] - start == 1:
+            troughs_fixed[ind+1] = troughs_fixed[ind] + cyc_len
+
+    ends = np.where(np.diff(starts) != 1)[0]
+
+    troughs_fixed = np.insert(troughs_fixed, ends+1, troughs_fixed[ends] + cyc_len)
+    troughs_fixed = np.insert(troughs_fixed, len(troughs_fixed), troughs_fixed[-1] + cyc_len)
+
+    # Split continuous bursts
+    split_inds = np.split(np.arange(len(troughs_fixed)),
+                          np.where(np.diff(troughs_fixed) != cyc_len)[0]+1)
+
+    # Find optimal x-axis translation, per burst
+    half_cyc = cyc_len // 2
+    shifts = np.arange(-half_cyc, half_cyc)
+
+    for inds in split_inds:
+        tsum = np.zeros(len(shifts))
+        for sind, shift in enumerate(shifts):
+            _troughs = troughs_fixed[inds].copy()
+            _troughs += shift
+            tsum[sind] = np.sum(sig[_troughs])
+
+        troughs_fixed[inds] += shifts[np.argmin(tsum)]
+
+    # Add peaks and non-updated troughs
+    t_inserts = []
+
+    for ind in range(len(peaks)-1):
+
+        current_peak = peaks[ind]
+        next_peak = peaks[ind+1]
+
+        _trough = np.where((troughs_fixed > current_peak) & (troughs_fixed < next_peak))[0]
+
+        if len(_trough) == 1:
+            troughs[ind] = troughs_fixed[_trough[0]]
+
+    return troughs


### PR DESCRIPTION
This adds an option to have redefine troughs on a burst-by-burst basis (assuming a fixed cycle duration), providing a solution to periods fluctuating +/- 10% of the simulated length when an oscillation is combined with noise. Outside of simulations, I don't think this update will be useful since a fixed cycle duration can't be assumed.

What led me here was poor fits when transforming motifs to individual cycles (i.e. when a simulated cycle has 50 samples, but bycycle defines the cycle as 45 samples, and transforming a 50 sample motif to the cycle leads to a poor fit, typically at the edge that is over/under defined). This is shown in the image below - this example has a tiny amount of noise that still throws off the cyclepoint definitions a little.
![Screenshot_20210909_184422](https://user-images.githubusercontent.com/34786005/132785479-039bfda6-c493-4caa-ae5f-31d9a763ff13.png)
