### PR TITLE
[ENH] Access df columns as attributes

### DIFF
--- a/bycycle/objs/fit.py
+++ b/bycycle/objs/fit.py
@@ -92,6 +92,23 @@ class Bycycle:
         self.df_features = None
 
 
+    def __getattr__(self, key):
+        """Access df_features columns as class attributes.
+
+        Parameters
+        ----------
+        key : str
+            Column name.
+
+        Returns
+        -------
+        1d-array
+            Column values.
+        """
+        if self.df_features is not None and key in self.df_features.keys():
+            return self.df_features[key].values
+
+
     def fit(self, sig, fs, f_range):
         """Run the bycycle algorithm on a signal.
 

--- a/bycycle/tests/objs/test_fit.py
+++ b/bycycle/tests/objs/test_fit.py
@@ -48,6 +48,9 @@ def test_bycycle_fit(sim_args):
     assert bm.f_range == f_range
     assert (bm.sig == sig).all()
 
+    # test getting attribute from dataframe
+    assert (bm.df_features['time_peak'].values == bm.time_peak).all()
+
 
 @plot_test
 def test_bycycle_plot(sim_args):


### PR DESCRIPTION
After a model is fit, df column arrays may now be accessed as attributes:

```python
bm = Bycycle()
bm.fit(sig, FS, F_RANGE)
bm.time_peak
```

before:
```python
bm.df_features['time_peak'].values
```