### PR TITLE
[TST] Add persistent hash test

### DIFF
--- a/bycycle/tests/test_persistence.py
+++ b/bycycle/tests/test_persistence.py
@@ -7,7 +7,7 @@ import numpy as np
 ###################################################################################################
 
 # Update when a commit alters the result of compute_features
-PERSISTENT_HASH = 'a251877069bd9f960b8aee9537eee5c7856e0b34'
+PERSISTENT_HASH = '502ca93eee58f97caf83d42b866c9bab7f0074fb'
 
 def test_persistent_features(sim_args_comb):
 
@@ -15,7 +15,7 @@ def test_persistent_features(sim_args_comb):
     df_features = sim_args_comb['df_features']
 
     # Convert to np array
-    arr_features = df_features.to_numpy().astype(np.float64).copy(order='C')
+    arr_features = df_features.to_numpy().astype(np.float32).copy(order='C')
 
     # Hash
     h = sha1()

--- a/bycycle/tests/test_persistence.py
+++ b/bycycle/tests/test_persistence.py
@@ -1,0 +1,25 @@
+"""Test the persistence of computed features across versions of bycycle."""
+
+from hashlib import sha1
+import numpy as np
+
+###################################################################################################
+###################################################################################################
+
+# Update when a commit alters the result of compute_features
+PERSISTENT_HASH = 'a251877069bd9f960b8aee9537eee5c7856e0b34'
+
+def test_persistent_features(sim_args_comb):
+
+    # Get df from pytest fixture
+    df_features = sim_args_comb['df_features']
+
+    # Convert to np array
+    arr_features = df_features.to_numpy().astype(np.float64).copy(order='C')
+
+    # Hash
+    h = sha1()
+    h.update(arr_features)
+    arr_hash = h.hexdigest()
+
+    assert arr_hash == PERSISTENT_HASH


### PR DESCRIPTION
Adds a test to ensure the computed features are consistent from version to version and from PR to PR. This is to ensure there are no changes in how features are computed without an explicit warning from a failed test. The `PERSISTENT_HASH` variable must be updated/committed when a change to the output df/array is expected. Here, the df is converted to an array, then hashed using sha-1 (same algorithm that git uses), so we don't have to track a large array/df in git history.

@TomDonoghue if this looks useful, I could eventually add a similar thing to specparam/neurodsp?
