### PR TITLE
[ENH] Optimize check_min_burst_cycles

### DIFF
--- a/bycycle/burst/amp.py
+++ b/bycycle/burst/amp.py
@@ -1,4 +1,5 @@
 """Detect bursts: amplitude threshold approach."""
+import numpy as np
 
 from bycycle.utils.checks import check_param_range
 from bycycle.burst.utils import check_min_burst_cycles
@@ -42,6 +43,7 @@ def detect_bursts_amp(df_features, burst_fraction_threshold=1, min_n_cycles=3):
 
     # Determine cycles that are defined as bursting throughout the whole cycle
     is_burst = [frac >= burst_fraction_threshold for frac in df_features['burst_fraction']]
+    is_burst = np.array(is_burst)
 
     df_features['is_burst'] = check_min_burst_cycles(is_burst, min_n_cycles=min_n_cycles)
 

--- a/bycycle/burst/cycle.py
+++ b/bycycle/burst/cycle.py
@@ -90,6 +90,7 @@ def detect_bursts_cycles(df_features, amp_fraction_threshold=0., amp_consistency
 
     # Set the burst status for each cycle as the answer across all criteria
     is_burst = amp_fraction & amp_consistency & period_consistency & monotonicity
+    is_burst = is_burst.to_numpy()
 
     # Set the first and last cycles to not be part of a burst
     is_burst[0] = False

--- a/bycycle/burst/utils.py
+++ b/bycycle/burst/utils.py
@@ -12,15 +12,15 @@ def check_min_burst_cycles(is_burst, min_n_cycles=3):
 
     Parameters
     ----------
-    is_burst : 1d array
+    is_burst : 1d array-like
         Boolean array indicating which cycles are bursting.
     min_n_cycles : int, optional, default: 3
         The minimum number of cycles of consecutive cycles required to be considered a burst.
 
     Returns
     -------
-    is_burst : 1d array
-        Updated burst array.
+    is_burst : 1d array-like
+        Updated burst array with same type as input.
 
     Examples
     --------
@@ -30,6 +30,7 @@ def check_min_burst_cycles(is_burst, min_n_cycles=3):
     >>> check_min_burst_cycles(is_burst)
     array([False, False, False, False,  True,  True,  True,  True, False])
     """
+
     # Ensure argument is within valid range
     check_param_range(min_n_cycles, 'min_n_cycles', (0, np.inf))
 

--- a/bycycle/burst/utils.py
+++ b/bycycle/burst/utils.py
@@ -12,15 +12,15 @@ def check_min_burst_cycles(is_burst, min_n_cycles=3):
 
     Parameters
     ----------
-    is_burst : 1d array-like
+    is_burst : 1d array
         Boolean array indicating which cycles are bursting.
     min_n_cycles : int, optional, default: 3
         The minimum number of cycles of consecutive cycles required to be considered a burst.
 
     Returns
     -------
-    is_burst : 1d array-like
-        Updated burst array with same type as input.
+    is_burst : 1d array
+        Updated burst array.
 
     Examples
     --------
@@ -31,7 +31,10 @@ def check_min_burst_cycles(is_burst, min_n_cycles=3):
     array([False, False, False, False,  True,  True,  True,  True, False])
     """
 
-    # handle special case where input iterable is empty
+    if not isinstance(is_burst, np.ndarray):
+        raise ValueError("Argument 'is_burst' must be a numpy array!")
+
+    # handle special case where input array is empty
     if len(is_burst) == 0:
         return is_burst
 
@@ -45,14 +48,11 @@ def check_min_burst_cycles(is_burst, min_n_cycles=3):
 
     # select only segments with long enough duration
     durations = offs - ons
-    long_enough = durations >= min_n_cycles
-    ons, offs = ons[long_enough], offs[long_enough]
+    too_short = durations < min_n_cycles
 
     # construct bool time series from transition indices
-    is_burst[:] = [False] * len(is_burst)
-    for turn_on, turn_off in zip(ons, offs):
-        n_cycles = turn_off - turn_on
-        is_burst[turn_on:turn_off] = [True] * n_cycles
+    for silence_on, silence_off in zip(ons[too_short], offs[too_short]):
+        is_burst[silence_on:silence_off] = False
 
     return is_burst
 

--- a/bycycle/burst/utils.py
+++ b/bycycle/burst/utils.py
@@ -30,24 +30,23 @@ def check_min_burst_cycles(is_burst, min_n_cycles=3):
     >>> check_min_burst_cycles(is_burst)
     array([False, False, False, False,  True,  True,  True,  True, False])
     """
-
     # Ensure argument is within valid range
     check_param_range(min_n_cycles, 'min_n_cycles', (0, np.inf))
 
-    temp_cycle_count = 0
+    # extract transition indices
+    diff = np.diff(is_burst, prepend=0, append=0)
+    transitions = np.flatnonzero(diff)
+    ons, offs = transitions[0::2], transitions[1::2]
 
-    for idx, bursting in enumerate(is_burst):
+    # select only segments with long enough duration
+    durations = offs - ons
+    long_enough = durations >= min_n_cycles
+    ons, offs = ons[long_enough], offs[long_enough]
 
-        if bursting:
-            temp_cycle_count += 1
-
-        else:
-
-            if temp_cycle_count < min_n_cycles:
-                for c_rm in range(temp_cycle_count):
-                    is_burst[idx - 1 - c_rm] = False
-
-            temp_cycle_count = 0
+    # construct bool time series from transition indices
+    is_burst[:] = False
+    for turn_on, turn_off in zip(ons, offs):
+        is_burst[turn_on:turn_off] = True
 
     return is_burst
 

--- a/bycycle/burst/utils.py
+++ b/bycycle/burst/utils.py
@@ -31,6 +31,10 @@ def check_min_burst_cycles(is_burst, min_n_cycles=3):
     array([False, False, False, False,  True,  True,  True,  True, False])
     """
 
+    # handle special case where input iterable is empty
+    if len(is_burst) == 0:
+        return is_burst
+
     # Ensure argument is within valid range
     check_param_range(min_n_cycles, 'min_n_cycles', (0, np.inf))
 
@@ -45,9 +49,10 @@ def check_min_burst_cycles(is_burst, min_n_cycles=3):
     ons, offs = ons[long_enough], offs[long_enough]
 
     # construct bool time series from transition indices
-    is_burst[:] = False
+    is_burst[:] = [False] * len(is_burst)
     for turn_on, turn_off in zip(ons, offs):
-        is_burst[turn_on:turn_off] = True
+        n_cycles = turn_off - turn_on
+        is_burst[turn_on:turn_off] = [True] * n_cycles
 
     return is_burst
 

--- a/bycycle/tests/burst/test_utils.py
+++ b/bycycle/tests/burst/test_utils.py
@@ -22,6 +22,15 @@ def test_check_min_burst_cycles():
     assert not any(is_burst_check)
 
 
+def test_check_min_burst_cycles_no_bursts():
+
+    num_cycles = 5
+    is_burst = np.zeros(num_cycles, dtype=bool)
+    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=3)
+
+    assert not any(is_burst_check)
+
+
 def test_recompute_edges(sim_args_comb):
 
     # Grab sim arguments from fixture

--- a/bycycle/tests/burst/test_utils.py
+++ b/bycycle/tests/burst/test_utils.py
@@ -1,6 +1,7 @@
 """Test burst.utils."""
 
 import numpy as np
+import pytest
 
 from bycycle.features import compute_features
 from bycycle.burst.utils import *
@@ -9,15 +10,30 @@ from bycycle.burst.utils import *
 ###################################################################################################
 ###################################################################################################
 
-def test_check_min_burst_cycles():
+@pytest.mark.parametrize("min_n_cycles", [2, 3])
+def test_check_min_burst_cycles_bursting_at_start(min_n_cycles):
 
     is_burst = np.array([True, True, True, False])
-    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=3)
+    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=min_n_cycles)
 
     assert (is_burst == is_burst_check).all()
 
     is_burst = np.array([True, False, True, False])
-    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=3)
+    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=min_n_cycles)
+
+    assert not any(is_burst_check)
+
+
+@pytest.mark.parametrize("min_n_cycles", [2, 3])
+def test_check_min_burst_cycles_bursting_at_end(min_n_cycles):
+
+    is_burst = np.array([False, True, True, True])
+    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=min_n_cycles)
+
+    assert (is_burst == is_burst_check).all()
+
+    is_burst = np.array([False, True, False, True])
+    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=min_n_cycles)
 
     assert not any(is_burst_check)
 

--- a/bycycle/tests/burst/test_utils.py
+++ b/bycycle/tests/burst/test_utils.py
@@ -1,6 +1,7 @@
 """Test burst.utils."""
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from bycycle.features import compute_features
@@ -45,6 +46,24 @@ def test_check_min_burst_cycles_no_bursts():
     is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=3)
 
     assert not any(is_burst_check)
+
+
+def test_check_min_burst_cycles_empty_input():
+
+    is_burst = []
+    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=3)
+
+    assert not len(is_burst_check)
+
+
+@pytest.mark.parametrize("input_type", [list, np.array, pd.Series])
+def test_check_min_burst_cycles_output_type(input_type):
+
+    is_burst = [False, True, True, True]
+    is_burst = input_type(is_burst)
+    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=3)
+
+    assert type(is_burst) == type(is_burst_check)
 
 
 def test_recompute_edges(sim_args_comb):

--- a/bycycle/tests/burst/test_utils.py
+++ b/bycycle/tests/burst/test_utils.py
@@ -12,58 +12,46 @@ from bycycle.burst.utils import *
 ###################################################################################################
 
 @pytest.mark.parametrize("min_n_cycles", [2, 3])
-def test_check_min_burst_cycles_bursting_at_start(min_n_cycles):
+def test_check_min_burst_cycles(min_n_cycles):
 
-    is_burst = np.array([True, True, True, False])
-    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=min_n_cycles)
+    is_burst = np.array([False, True, True, False, False])
+
+    is_burst_check = check_min_burst_cycles(is_burst.copy(), min_n_cycles=min_n_cycles)
+
+    burst_should_be_kept = min_n_cycles < 3
+    burst_kept = (is_burst == is_burst_check).all()
+
+    assert burst_kept == burst_should_be_kept
+
+
+@pytest.mark.parametrize("side", ["start", "end"])
+def test_check_min_burst_cycles_bursting_at_side(side):
+
+    min_n_cycles = 5
+    is_burst = [True] * min_n_cycles + [False]
+    is_burst = np.flip(is_burst) if side == "end" else np.array(is_burst)
+
+    is_burst_check = check_min_burst_cycles(is_burst.copy(), min_n_cycles=min_n_cycles)
 
     assert (is_burst == is_burst_check).all()
-
-    is_burst = np.array([True, False, True, False])
-    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=min_n_cycles)
-
-    assert not any(is_burst_check)
-
-
-@pytest.mark.parametrize("min_n_cycles", [2, 3])
-def test_check_min_burst_cycles_bursting_at_end(min_n_cycles):
-
-    is_burst = np.array([False, True, True, True])
-    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=min_n_cycles)
-
-    assert (is_burst == is_burst_check).all()
-
-    is_burst = np.array([False, True, False, True])
-    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=min_n_cycles)
-
-    assert not any(is_burst_check)
 
 
 def test_check_min_burst_cycles_no_bursts():
 
     num_cycles = 5
     is_burst = np.zeros(num_cycles, dtype=bool)
-    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=3)
+
+    is_burst_check = check_min_burst_cycles(is_burst.copy(), min_n_cycles=3)
 
     assert not any(is_burst_check)
 
 
 def test_check_min_burst_cycles_empty_input():
 
-    is_burst = []
-    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=3)
+    is_burst = np.array([])
+    is_burst_check = check_min_burst_cycles(is_burst.copy(), min_n_cycles=3)
 
     assert not len(is_burst_check)
-
-
-@pytest.mark.parametrize("input_type", [list, np.array, pd.Series])
-def test_check_min_burst_cycles_output_type(input_type):
-
-    is_burst = [False, True, True, True]
-    is_burst = input_type(is_burst)
-    is_burst_check = check_min_burst_cycles(is_burst, min_n_cycles=3)
-
-    assert type(is_burst) == type(is_burst_check)
 
 
 def test_recompute_edges(sim_args_comb):


### PR DESCRIPTION
Closes #134 

Optimizations show consistent improvement in profiling (see linked issue for more details).

@ryanhammonds while working on this PR, I had the following observations -- looking for your feedback:

1. The original function doesn't particularly care what the type of `is_burst` is. When running the test suite, I caused failures after returning a `np.ndarray` because this function is used with `pd.Series` (and potentially other array-likes such as `list`). I've updated my code to operate directly on the input object to preserve type.
2. This function originally updates AND returns the input object. Depending on the input type, this could cause unexpected behavior. However, I'm leaving it as is for fear of breaking someone's project. Let me know if you think we should establish a more specific behavior.
3. I wanted to be particularly careful with these changes, so I implemented a bit more test coverage for the function. Let me know if you think this is out of scope. 

Thanks!