### PR TITLE
[MNT] - Update workflow tests to support Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       MODULE_NAME: bycycle
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/bycycle/plts/burst.py
+++ b/bycycle/plts/burst.py
@@ -242,7 +242,7 @@ def plot_burst_detect_param(df_features, sig, fs, burst_param, thresh,
 
         plot_time_series([times[df_features['sample_' + center_e]], (times[0], times[-1])],
                          [df_features[burst_param], [thresh]*2], ax=ax, colors=['k', 'k'],
-                         ls=['-', '--'], marker=["o", None], xlabel=xlabel,
+                         ls=['-', '--'], marker=["o", "None"], xlabel=xlabel,
                          ylabel="{0:s}\nthreshold={1:.2f}".format(ylabel, thresh), **kwargs)
 
     else:
@@ -262,7 +262,7 @@ def plot_burst_detect_param(df_features, sig, fs, burst_param, thresh,
             side_param = np.append(side_param, [cyc[burst_param]] * 2)
 
         plot_time_series([side_times, (times[0], times[-1])], [side_param, [thresh]*2], ax=ax,
-                         colors=['k', 'k'], ls=['-', '--'], marker=["o", None], xlabel=xlabel,
+                         colors=['k', 'k'], ls=['-', '--'], marker=["o", "None"], xlabel=xlabel,
                          ylabel="{0:s}\nthreshold={1:.2f}".format(ylabel, thresh), **kwargs)
 
     # Highlight where param falls below threshold

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     platforms = 'any',
     project_urls = {


### PR DESCRIPTION
This PR updates the workflow to test against 3.12, which is now available. 

Confusingly, in the workflow tests, version below 3.12 (which previously passed) are now failing - which is not happening when I run tests locally. It looks like (at least part of this) might be a plotting thing, as one of the error messages is about markerstyle. @ryanhammonds - any ideas what is happening here?

Edit - this was previously failing, but it turns out it was about #144 - now that that is merged here, it works!