### PR TITLE
[BUG] - Update marker definition for newer matplotlib

### DIFF
--- a/bycycle/plts/burst.py
+++ b/bycycle/plts/burst.py
@@ -242,7 +242,7 @@ def plot_burst_detect_param(df_features, sig, fs, burst_param, thresh,
 
         plot_time_series([times[df_features['sample_' + center_e]], (times[0], times[-1])],
                          [df_features[burst_param], [thresh]*2], ax=ax, colors=['k', 'k'],
-                         ls=['-', '--'], marker=["o", None], xlabel=xlabel,
+                         ls=['-', '--'], marker=["o", "None"], xlabel=xlabel,
                          ylabel="{0:s}\nthreshold={1:.2f}".format(ylabel, thresh), **kwargs)
 
     else:
@@ -262,7 +262,7 @@ def plot_burst_detect_param(df_features, sig, fs, burst_param, thresh,
             side_param = np.append(side_param, [cyc[burst_param]] * 2)
 
         plot_time_series([side_times, (times[0], times[-1])], [side_param, [thresh]*2], ax=ax,
-                         colors=['k', 'k'], ls=['-', '--'], marker=["o", None], xlabel=xlabel,
+                         colors=['k', 'k'], ls=['-', '--'], marker=["o", "None"], xlabel=xlabel,
                          ylabel="{0:s}\nthreshold={1:.2f}".format(ylabel, thresh), **kwargs)
 
     # Highlight where param falls below threshold


### PR DESCRIPTION
Issue: for current matplotlib version >= 3.8, they have deprecated passing in a marker definition as None to line style (see note in docs [here](https://matplotlib.org/stable/api/markers_api.html)). 

This update fixes this, so that None -> "None", which is interpreted as no marker style. 

Note / to check: I'm not sure if "None" will work on all older version of matplotlib - it is possible this changes behavior / creates an error on older matplotlibs. 