### PR TITLE
[BUG] dataframe memory fix

### DIFF
--- a/bycycle/objs/fit.py
+++ b/bycycle/objs/fit.py
@@ -447,5 +447,7 @@ class BycycleGroup(BycycleBase):
             if self.n_dims == 3:
                 for dim1 in range(len(sig)):
                     self.models[dim0][dim1].recompute_edges(reduction)
+                    self.df_features[dim0][dim1] = self.models[dim0][dim1].df_features
             else:
                  self.models[dim0].recompute_edges(reduction)
+                 self.df_features[dim0] = self.models[dim0].df_features


### PR DESCRIPTION
The recompute_edges method updates the dataframe in the group object, e.g. `bg[i].df_features`. Access from `bg.df_features[i]` wouldn't get updated in the process. This adds a fix.