### PR TITLE
[MNT] - Update filter defaults

### DIFF
--- a/bycycle/cyclepoints/extrema.py
+++ b/bycycle/cyclepoints/extrema.py
@@ -65,6 +65,8 @@ def find_extrema(sig, fs, f_range, boundary=0, first_extrema='peak',
     # Set default filtering parameters
     if filter_kwargs is None:
         filter_kwargs = {}
+        # If not defined, set default filter length (ndsp defaults to n_cycles of 3)
+        filter_kwargs['n_cycles'] = 3
 
     # Get the original signal and filter lengths
     sig_len = len(sig)
@@ -75,7 +77,7 @@ def find_extrema(sig, fs, f_range, boundary=0, first_extrema='peak',
 
         filt_len = compute_filter_length(fs, pass_type, f_range[0], f_range[1],
                                          n_seconds=filter_kwargs.get('n_seconds', None),
-                                         n_cycles=filter_kwargs.get('n_cycles', 3))
+                                         n_cycles=filter_kwargs.get('n_cycles', None))
 
         # Pad the signal
         sig = np.pad(sig, int(np.ceil(filt_len/2)), mode='constant')


### PR DESCRIPTION
In recent neurodsp updates, we got a bit stricter about filter parameters & inputs [here](https://github.com/neurodsp-tools/neurodsp/pull/322)

In the bycycle `find_extrema` function, it takes filter kwargs, and then uses any given arguments to compute the length of the filter for doing some extra padding. Because we are now stricter, some inputs can now fail (for example, as done in  tutorial # 2), if trying to pass in a specified `n_seconds` filter kwarg:
```
peaks, troughs = find_extrema(sig, fs, range, filter_kwargs={'n_seconds':n_seconds})
```
This is because the function also default `n_cycles` to 3, leading to both inputs being defined and passed in, and while this used to work, neurodsp no longer allows this kind of inconsistent input. 

To address this, this PR updates the filter_kwargs management, to only default to setting n_cycles to the default value of 3 if there are no specified filter kwargs. 