### PR TITLE
[MNT] - Add pandas max version (< 3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy >= 1.18.5
 scipy >=  1.4.1
-pandas >= 0.25.3
+pandas >= 0.25.3, < 3.0.0
 matplotlib >= 3.0.3
 neurodsp >= 2.2.1


### PR DESCRIPTION
Adds a max version for pandas, tagging to <3.0, as something changes at that point about assigning values (I think an interaction with numpy arrays) - so some maintenance work is required to make that work. 